### PR TITLE
docs: add principled-quality to marketplace README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A Claude Code plugin marketplace hosting first-party and community plugins for t
 | [**principled-docs**](plugins/principled-docs/README.md)                     | documentation  | Scaffold, author, and enforce module documentation structure following the Principled specification-first methodology (v0.3.1)  |
 | [**principled-implementation**](plugins/principled-implementation/README.md) | implementation | Orchestrate DDD plan execution via worktree-isolated Claude Code agents (v0.1.0)                                                |
 | [**principled-github**](plugins/principled-github/README.md)                 | workflow       | Integrate the principled workflow with GitHub native features: issues, PRs, templates, actions, CODEOWNERS, and labels (v0.1.0) |
+| [**principled-quality**](plugins/principled-quality/README.md)               | quality        | Connect code reviews to the principled documentation pipeline with spec-driven checklists and review tracking (v0.1.0)          |
 
 ### Community
 
@@ -44,6 +45,7 @@ _No community plugins yet. See [Contributing](#-contributing-a-plugin) to submit
 /plugin install principled-docs@principled-marketplace
 /plugin install principled-implementation@principled-marketplace
 /plugin install principled-github@principled-marketplace
+/plugin install principled-quality@principled-marketplace
 ```
 
 ### Team-Wide Adoption
@@ -63,7 +65,8 @@ Add to your project's `.claude/settings.json`:
   "enabledPlugins": {
     "principled-docs@principled-marketplace": true,
     "principled-implementation@principled-marketplace": true,
-    "principled-github@principled-marketplace": true
+    "principled-github@principled-marketplace": true,
+    "principled-quality@principled-marketplace": true
   }
 }
 ```
@@ -77,7 +80,8 @@ principled/
 ├── plugins/                     # First-party plugins
 │   ├── principled-docs/         # Documentation structure plugin
 │   ├── principled-implementation/ # Plan execution plugin
-│   └── principled-github/       # GitHub integration plugin
+│   ├── principled-github/       # GitHub integration plugin
+│   └── principled-quality/      # Code review quality plugin
 ├── external_plugins/            # Community plugins
 ├── docs/                        # Marketplace governance
 │   ├── proposals/               # RFCs


### PR DESCRIPTION
## Summary

- Adds `principled-quality` (v0.1.0) to the available plugins table in the main README
- Adds the install command to the Quick Start section
- Adds the plugin to the team-wide settings example
- Updates the directory structure diagram

## Test plan

- [x] markdownlint passes
- [x] Prettier passes
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)