### PR TITLE
docs: ADR, architecture doc, and DDD plan for principled-release (RFC-004)

### DIFF
--- a/docs/architecture/release-system.md
+++ b/docs/architecture/release-system.md
@@ -1,0 +1,177 @@
+---
+title: "Release System Architecture"
+last_updated: 2026-02-22
+related_adrs: [013]
+---
+
+# Release System Architecture
+
+## Purpose
+
+Describes the architecture of the principled-release plugin: how it synthesizes changelogs from the documentation pipeline, verifies release readiness, coordinates version bumps, and governs the release lifecycle. Intended for contributors who need to understand or extend the release plugin, and for teams evaluating how principled releases connect specification to delivery.
+
+## Overview
+
+The release system bridges the gap between the principled documentation pipeline and the delivery boundary. It operates on the output of the existing pipeline (proposals, plans, ADRs, PRs) to produce release artifacts (changelogs, version bumps, release notes, tags).
+
+```
+┌───────────────────────────────────────────────────────────────┐
+│                    RELEASE LIFECYCLE                           │
+│                                                               │
+│  /release-plan ──▶ /changelog ──▶ /release-ready ──▶ /tag    │
+│    (draft)          (generate)      (verify)         (ship)   │
+│                                                               │
+├───────────────────────────────────────────────────────────────┤
+│                    INPUT: PIPELINE ARTIFACTS                   │
+│                                                               │
+│  Proposals (why)  ──┐                                         │
+│  Plans (how)      ──┼──▶  Change mapping  ──▶  Changelog      │
+│  ADRs (decisions) ──┤                                         │
+│  PRs (references) ──┘                                         │
+│                                                               │
+├───────────────────────────────────────────────────────────────┤
+│                    OUTPUT: RELEASE ARTIFACTS                   │
+│                                                               │
+│  Changelog entries, version bumps, release notes, git tags    │
+└───────────────────────────────────────────────────────────────┘
+```
+
+## Key Abstractions
+
+### Change Mapping
+
+The core abstraction is the **change map**: a data structure that links git commits to their governing pipeline documents. Change mapping resolves through three mechanisms, in priority order:
+
+1. **PR description references** — The `/pr-describe` skill (principled-github) embeds structured references to proposals, plans, and ADRs in PR bodies. These are the most reliable source.
+2. **Commit message references** — Direct references like `RFC-001`, `Plan-001`, `ADR-005` in commit messages.
+3. **Branch naming conventions** — Branch names like `plan-001/task-3` imply a link to Plan-001, Task 3.
+
+Changes that match no pipeline document are classified as "uncategorized."
+
+### Release Readiness
+
+A **readiness check** verifies that all pipeline documents referenced by merged changes have reached terminal status:
+
+- Plans referenced by merged PRs must be `complete` (or `abandoned` with justification)
+- Proposals referenced by merged code must be `accepted` (not `draft` or `in-review`)
+- ADRs referenced by merged code must be `accepted`
+
+Readiness has two modes: default (warnings) and strict (hard failures).
+
+### Version Bump Heuristics
+
+Version bumps are derived from the nature of changes:
+
+| Change Signal                       | Bump Type |
+| ----------------------------------- | --------- |
+| ADR or proposal marked `supersedes` | major     |
+| Accepted proposal (new capability)  | minor     |
+| Plan tasks (improvements, fixes)    | patch     |
+
+The `--type` flag overrides automatic detection. Module-scoped bumps are supported via `--module`.
+
+## Component Relationships
+
+```
+                      /release-plan
+                           │
+              drafts summary of pending changes
+                           │
+                           ▼
+                      /changelog ◄──── collect-changes.sh
+                           │               │
+              generates entries from        scans git log,
+              pipeline references           resolves PR refs
+                           │
+                           ▼
+                    /release-ready ◄──── check-readiness.sh
+                           │                │
+              verifies all plans/          reads frontmatter
+              proposals/ADRs are          status of referenced
+              in terminal status           documents
+                           │
+                           ▼
+                     /tag-release ◄──── validate-tag.sh
+                           │                │
+              creates git tag,            checks tag format,
+              generates release           prevents duplicate
+              notes, optionally           tags
+              creates GH release
+                           │
+                           ▼
+                    /version-bump ◄──── detect-modules.sh
+                                            │
+              bumps version manifests      finds CLAUDE.md
+              (package.json, etc.)         declarations,
+                                           identifies version
+                                           manifest files
+```
+
+## Data Flow
+
+### Changelog Generation Flow
+
+```
+git log --since=<last-tag>
+       │
+       ▼
+Collect commit SHAs
+       │
+       ▼
+For each commit, resolve PR ──▶ gh pr view
+       │
+       ▼
+Parse PR body for pipeline references
+(RFC-NNN, Plan-NNN, ADR-NNN patterns)
+       │
+       ▼
+Group changes by category:
+  ├── Features (from accepted proposals)
+  ├── Improvements (from plan tasks)
+  ├── Decisions (from ADRs)
+  └── Uncategorized (no pipeline reference)
+       │
+       ▼
+Render via changelog-entry.md template
+       │
+       ▼
+Output: Markdown changelog section
+```
+
+### Release Readiness Flow
+
+```
+Collect all pipeline refs from merged PRs since <tag>
+       │
+       ▼
+For each referenced document:
+  ├── Proposal: read frontmatter status
+  │   ├── accepted ──▶ OK
+  │   ├── draft/in-review ──▶ WARNING (or FAIL in strict)
+  │   └── rejected/superseded ──▶ OK (but flagged)
+  │
+  ├── Plan: read frontmatter status
+  │   ├── complete ──▶ OK
+  │   ├── active ──▶ WARNING (or FAIL in strict)
+  │   └── abandoned ──▶ OK (flagged for review)
+  │
+  └── ADR: read frontmatter status
+      ├── accepted ──▶ OK
+      ├── proposed ──▶ WARNING (or FAIL in strict)
+      └── deprecated/superseded ──▶ OK (flagged)
+       │
+       ▼
+Output: Pass/fail summary with details
+```
+
+## Key Decisions
+
+- [ADR-013: Pipeline-Based Changelog Generation](../decisions/013-pipeline-based-changelog-generation.md) — Changelogs are synthesized from the documentation pipeline rather than from commit messages or CI automation.
+
+## Constraints and Invariants
+
+1. **Documents are the source of truth.** Changelogs reference pipeline documents; they do not replace them. The changelog is a synthesis artifact, not a primary record.
+2. **Interactive, not autonomous.** Release skills generate drafts for human review. `/tag-release` is the only skill that makes irreversible changes (git tags), and it supports `--dry-run`.
+3. **Release stops at the tag.** The plugin creates git tags and release notes but does not handle deployment, environment promotion, or rollback. This boundary is intentional.
+4. **Uncategorized changes are visible.** Changes without pipeline references appear in the changelog as "uncategorized" rather than being hidden. This preserves completeness and creates pressure to improve reference discipline.
+5. **Version manifests are detected, not configured.** `/version-bump` discovers version files (package.json, Cargo.toml, etc.) from module structure rather than requiring explicit configuration.

--- a/docs/decisions/013-pipeline-based-changelog-generation.md
+++ b/docs/decisions/013-pipeline-based-changelog-generation.md
@@ -1,0 +1,118 @@
+---
+title: "Pipeline-Based Changelog Generation"
+number: "013"
+status: proposed
+author: Alex
+created: 2026-02-22
+updated: 2026-02-22
+from_proposal: "004"
+supersedes: null
+superseded_by: null
+---
+
+# ADR-013: Pipeline-Based Changelog Generation
+
+## Status
+
+Proposed
+
+<!-- Valid values: proposed, accepted, deprecated, superseded -->
+<!-- Once accepted, this document is IMMUTABLE. -->
+<!-- Exception: superseded_by may be updated when a new ADR supersedes this one. -->
+
+## Context
+
+The principled pipeline produces rich metadata about every change: proposals explain the "why," plans describe the "how," and ADRs record architectural decisions. When cutting a release, this metadata is available but not synthesized — teams must manually trace which pipeline documents correspond to which changes.
+
+Three approaches exist for changelog generation:
+
+1. **Conventional Commits** — Parse commit messages (feat:, fix:, etc.) to generate changelogs. Widely adopted but limited to one-line summaries disconnected from the specification pipeline.
+2. **CI-only automation** — GitHub Actions generate changelogs on tag push. Fully automated but non-interactive, offering no opportunity for human review before finalization.
+3. **Pipeline-based generation** — Map commits to proposals, plans, and ADRs, then synthesize changelog entries that reference the governing specifications.
+
+The principled methodology already requires PR descriptions to reference pipeline documents (principled-github's `/pr-describe`). This creates a traceable link from merged code back to specifications.
+
+## Decision
+
+Changelogs are generated from the documentation pipeline rather than from commit messages or CI automation.
+
+This means:
+
+- `/changelog` maps commits to proposals, plans, and ADRs via PR description references, commit message references (e.g., `RFC-001`, `Plan-001`), and branch naming conventions (e.g., `plan-001/task-3`)
+- Changelog entries include parenthetical references to originating specifications (e.g., "Added event sourcing support (RFC-001, Plan-001, ADR-001)")
+- Changes without pipeline references appear as "uncategorized" — visible rather than hidden — prompting teams to improve reference discipline
+- The changelog template follows [Keep a Changelog](https://keepachangelog.com/) conventions adapted for the principled pipeline
+- Generation is interactive via Claude Code skills, not fully automated, allowing human review and adjustment before finalization
+
+## Options Considered
+
+### Option 1: Conventional Commits
+
+Adopt Conventional Commits (feat:, fix:, etc.) for commit messages and generate changelogs from them using tools like `conventional-changelog`.
+
+**Pros:**
+
+- Well-established ecosystem with mature tooling
+- Low barrier to adoption — teams only need to follow a commit message convention
+- Works independently of any documentation pipeline
+
+**Cons:**
+
+- Commit messages carry far less context than proposals and ADRs
+- No link to specifications — "feat: add event sourcing" doesn't explain _why_ or what alternatives were considered
+- Duplicates information that already exists in the pipeline
+- Requires commit discipline that many teams struggle to maintain
+
+### Option 2: CI-only automation
+
+Generate changelogs in GitHub Actions triggered by tag push or release branch creation.
+
+**Pros:**
+
+- Fully automated — no manual steps
+- Runs consistently on every release
+- Can be combined with any changelog source (commits, PRs, pipeline docs)
+
+**Cons:**
+
+- Non-interactive — no opportunity to review or adjust before finalization
+- The principled approach values human review of specification artifacts; changelogs synthesize multiple specifications and should be reviewed
+- CI can _validate_ a changelog but generating it autonomously bypasses the review that makes principled artifacts valuable
+
+### Option 3: Pipeline-based generation (chosen)
+
+Map commits to proposals, plans, and ADRs and synthesize changelog entries with specification references.
+
+**Pros:**
+
+- Leverages the rich metadata already captured in the documentation pipeline
+- Changelog entries are strictly more informative than commit-based entries
+- Creates a complete audit trail from release notes back to original specifications
+- Interactive workflow allows human review and adjustment
+- Conventional Commits can serve as a fallback for unreferenced changes
+
+**Cons:**
+
+- Requires consistent pipeline references in PRs and commits
+- More complex implementation than commit-based generation
+- Depends on the quality of reference discipline across the team
+
+## Consequences
+
+### Positive
+
+- Changelogs become a synthesis of the documentation pipeline, not a separate artifact maintained in isolation.
+- Every changelog entry traces back to the specification that motivated it, providing full auditability.
+- Unreferenced changes are surfaced as "uncategorized," creating a natural feedback mechanism that improves pipeline reference discipline over time.
+- The interactive skill-based workflow preserves human judgment in changelog authoring while automating the heavy lifting of reference collection.
+
+### Negative
+
+- Teams that don't consistently reference pipeline documents in PRs will get sparse changelogs. This is mitigated by principled-github's `/pr-describe`, which auto-generates references.
+- The approach is principled-pipeline-specific — it doesn't produce useful changelogs for repositories not using the principled methodology.
+- Changelog generation requires traversing git history and PR metadata, which may be slow for repositories with large release deltas.
+
+## References
+
+- [RFC-004: Principled Release Plugin](../proposals/004-principled-release-plugin.md)
+- [ADR-011: Documents as Source of Truth](./011-documents-as-source-of-truth-in-sync.md) — establishes the document-first principle extended here to release artifacts

--- a/docs/plans/006-principled-release.md
+++ b/docs/plans/006-principled-release.md
@@ -1,0 +1,226 @@
+---
+title: "Principled Release Plugin"
+number: "006"
+status: active
+author: Alex
+created: 2026-02-22
+updated: 2026-02-22
+originating_proposal: "004"
+related_adrs: [013]
+---
+
+# Plan-006: Principled Release Plugin
+
+## Objective
+
+Implements [RFC-004](../proposals/004-principled-release-plugin.md).
+
+Build the `principled-release` Claude Code plugin end-to-end: plugin infrastructure, 6 skills (1 background + 5 user-invocable), 1 advisory hook, shared scripts with drift detection, reference documentation, templates, and a plugin README — following the directory layout and conventions established in the marketplace.
+
+The plugin bridges the principled documentation pipeline to the delivery boundary, synthesizing changelogs from proposals/plans/ADRs, verifying release readiness, coordinating version bumps, and governing the release lifecycle per [ADR-013](../decisions/013-pipeline-based-changelog-generation.md).
+
+---
+
+## Domain Analysis
+
+### Bounded Contexts
+
+This implementation decomposes into **6 bounded contexts**, each representing a distinct area of domain responsibility within the plugin:
+
+| #    | Bounded Context           | Responsibility                                                              | Key Artifacts                                              |
+| ---- | ------------------------- | --------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| BC-1 | **Plugin Infrastructure** | Plugin manifest, directory skeleton, marketplace integration                | `plugin.json`, directory tree, `marketplace.json`          |
+| BC-2 | **Knowledge System**      | Background knowledge on release conventions, changelog format, semver rules | `release-strategy/` skill with reference docs              |
+| BC-3 | **Change Collection**     | Map commits to pipeline documents, collect changes since last release       | `changelog/scripts/collect-changes.sh`, changelog template |
+| BC-4 | **Release Verification**  | Check that all referenced pipeline documents are in terminal status         | `release-ready/scripts/check-readiness.sh`                 |
+| BC-5 | **Version Coordination**  | Detect modules, determine bump type, apply version changes to manifests     | `version-bump/scripts/detect-modules.sh`                   |
+| BC-6 | **Release Orchestration** | Draft release plans, tag releases, generate release notes                   | `release-plan/`, `tag-release/` skills                     |
+
+### Aggregates
+
+#### BC-1: Plugin Infrastructure
+
+| Aggregate          | Root Entity   | Description                                                               |
+| ------------------ | ------------- | ------------------------------------------------------------------------- |
+| **PluginManifest** | `plugin.json` | Plugin identity, version, metadata                                        |
+| **DirectoryTree**  | Plugin root   | Complete directory skeleton for all skills, hooks, scripts, and templates |
+
+#### BC-2: Knowledge System
+
+| Aggregate              | Root Entity              | Description                                                        |
+| ---------------------- | ------------------------ | ------------------------------------------------------------------ |
+| **ReleaseConventions** | `release-conventions.md` | Changelog format, Keep a Changelog adaptation, entry grouping      |
+| **SemverRules**        | `semver-rules.md`        | How change types map to version bumps, override rules, pre-release |
+
+#### BC-3: Change Collection
+
+| Aggregate            | Root Entity          | Description                                                              |
+| -------------------- | -------------------- | ------------------------------------------------------------------------ |
+| **ChangeCollector**  | `collect-changes.sh` | Traverses git log, resolves PR references, maps commits to pipeline docs |
+| **ChangelogBuilder** | `changelog/SKILL.md` | Synthesizes collected changes into Markdown changelog entries            |
+| **EntryTemplate**    | `changelog-entry.md` | Template for changelog sections following Keep a Changelog format        |
+
+#### BC-4: Release Verification
+
+| Aggregate             | Root Entity              | Description                                                       |
+| --------------------- | ------------------------ | ----------------------------------------------------------------- |
+| **ReadinessChecker**  | `check-readiness.sh`     | Reads frontmatter status of referenced proposals, plans, and ADRs |
+| **ReadinessReporter** | `release-ready/SKILL.md` | Evaluates readiness results and reports pass/fail with details    |
+
+#### BC-5: Version Coordination
+
+| Aggregate          | Root Entity             | Description                                                    |
+| ------------------ | ----------------------- | -------------------------------------------------------------- |
+| **ModuleDetector** | `detect-modules.sh`     | Finds modules via CLAUDE.md, identifies version manifest files |
+| **BumpCalculator** | `version-bump/SKILL.md` | Determines bump type from change signals, applies to manifests |
+
+#### BC-6: Release Orchestration
+
+| Aggregate          | Root Entity             | Description                                                             |
+| ------------------ | ----------------------- | ----------------------------------------------------------------------- |
+| **ReleasePlanner** | `release-plan/SKILL.md` | Drafts release plan summarizing pending changes by module/category      |
+| **ReleaseTag**     | `tag-release/SKILL.md`  | Validates, tags, generates release notes, optionally creates GH release |
+| **TagValidator**   | `validate-tag.sh`       | Checks tag format, prevents duplicate tags                              |
+
+### Domain Events
+
+| Event                  | Source Context      | Target Context(s)                         | Description                                                             |
+| ---------------------- | ------------------- | ----------------------------------------- | ----------------------------------------------------------------------- |
+| **ChangesCollected**   | BC-3 (Collection)   | BC-4 (Verification), BC-6 (Orchestration) | Changes mapped to pipeline docs; readiness can be checked, plan drafted |
+| **ReadinessVerified**  | BC-4 (Verification) | BC-6 (Orchestration)                      | All references in terminal status; release can proceed                  |
+| **VersionDetermined**  | BC-5 (Coordination) | BC-6 (Orchestration)                      | Version bumps calculated; tag can be created                            |
+| **ChangelogGenerated** | BC-3 (Collection)   | BC-6 (Orchestration)                      | Changelog entries rendered; release notes can be assembled              |
+
+---
+
+## Implementation Tasks
+
+Tasks are organized by phase, with each phase mapping to one or more bounded contexts. Dependencies between phases are explicit.
+
+### Phase 1: Plugin Skeleton & Infrastructure (BC-1)
+
+**Goal:** Create the plugin manifest, directory structure, and marketplace integration.
+
+- [ ] **1.1** Create `plugins/principled-release/.claude-plugin/plugin.json` with name `principled-release`, version `0.1.0`, description, author, keywords (`release`, `changelog`, `versioning`, `semver`)
+- [ ] **1.2** Create full directory skeleton:
+  - `skills/release-strategy/`, `skills/changelog/`, `skills/release-ready/`, `skills/version-bump/`, `skills/release-plan/`, `skills/tag-release/`
+  - `hooks/scripts/`
+  - `scripts/` (plugin-level drift checker)
+- [ ] **1.3** Add plugin entry to `.claude-plugin/marketplace.json` with category `workflow`
+- [ ] **1.4** Add `principled-release@principled-marketplace` to `.claude/settings.json` enabled plugins
+
+### Phase 2: Knowledge Base & Shared Scripts (BC-2, BC-3)
+
+**Goal:** Implement background knowledge and shared utilities.
+
+**Depends on:** Phase 1
+
+- [ ] **2.1** Write `release-strategy/reference/release-conventions.md`: Keep a Changelog adaptation, entry format, grouping categories (Features, Improvements, Decisions, Uncategorized), pipeline reference syntax
+- [ ] **2.2** Write `release-strategy/reference/semver-rules.md`: bump type heuristics (supersedes → major, accepted proposals → minor, plan tasks → patch), `--type` override behavior, pre-release version handling
+- [ ] **2.3** Write `release-strategy/SKILL.md`: background knowledge skill, not user-invocable
+- [ ] **2.4** Copy `check-gh-cli.sh` from principled-github canonical source (`plugins/principled-github/skills/sync-issues/scripts/`) to `changelog/scripts/`
+- [ ] **2.5** Implement `changelog/scripts/collect-changes.sh`: accept `--since <tag>` and optional `--module <path>`, traverse git log, resolve PR references via `gh pr view`, extract pipeline document references (RFC-NNN, Plan-NNN, ADR-NNN patterns), output structured change list
+
+### Phase 3: Changelog Skill (BC-3)
+
+**Goal:** Implement the core changelog generation skill.
+
+**Depends on:** Phase 2
+
+- [ ] **3.1** Create `changelog/templates/changelog-entry.md`: template with `{{VERSION}}`, `{{DATE}}`, `{{FEATURES}}`, `{{IMPROVEMENTS}}`, `{{DECISIONS}}`, `{{UNCATEGORIZED}}` placeholders
+- [ ] **3.2** Write `changelog/SKILL.md`: user-invocable, accepts `--since <tag>` and `--module <path>`, runs `collect-changes.sh`, groups by category, renders via template, outputs Markdown changelog section
+
+### Phase 4: Release Readiness Skill (BC-4)
+
+**Goal:** Implement pre-release verification.
+
+**Depends on:** Phase 2
+
+- [ ] **4.1** Implement `release-ready/scripts/check-readiness.sh`: accept `--since <tag>`, collect pipeline references from merged PRs, read frontmatter status of each referenced document, report pass/fail per document, support `--strict` flag for hard failures
+- [ ] **4.2** Write `release-ready/SKILL.md`: user-invocable, accepts `--tag <version>` and `--strict`, runs `check-readiness.sh`, reports summary with blocking items, optionally runs structure validation on affected modules
+
+### Phase 5: Version Bump Skill (BC-5)
+
+**Goal:** Implement monorepo-aware version coordination.
+
+**Depends on:** Phase 2
+
+- [ ] **5.1** Implement `version-bump/scripts/detect-modules.sh`: find CLAUDE.md files, parse module type, locate version manifest files (package.json, Cargo.toml, pyproject.toml), output module-to-manifest mapping
+- [ ] **5.2** Write `version-bump/SKILL.md`: user-invocable, accepts `--module <path>` and `--type major|minor|patch`, runs `detect-modules.sh`, determines bump type from change signals (or uses `--type` override), applies version change to manifest, reports what was bumped and why
+
+### Phase 6: Release Plan & Tag Skills (BC-6)
+
+**Goal:** Implement release planning and tagging orchestration.
+
+**Depends on:** Phases 3, 4, 5
+
+- [ ] **6.1** Create `release-plan/templates/release-plan.md`: template with modules affected, features included, decisions included, outstanding items, suggested timeline
+- [ ] **6.2** Write `release-plan/SKILL.md`: user-invocable, accepts `--since <tag>`, collects changes, groups by module and category, generates plan document for team review
+- [ ] **6.3** Implement `tag-release/scripts/validate-tag.sh`: check tag format (vX.Y.Z), check tag doesn't already exist, validate against readiness state
+- [ ] **6.4** Write `tag-release/SKILL.md`: user-invocable, accepts `<version>` and `--dry-run`, runs `/release-ready --strict`, generates changelog, creates git tag, generates release notes, optionally creates GitHub release via `gh release create`
+
+### Phase 7: Hook, Drift Detection & Documentation (BC-1, BC-6)
+
+**Goal:** Implement advisory hook, propagate script copies, finalize documentation.
+
+**Depends on:** Phases 3, 4, 5, 6
+
+- [ ] **7.1** Implement `hooks/scripts/check-release-readiness.sh`: PostToolUse hook for Bash, reads stdin JSON, detects `git tag` commands, warns if `/release-ready` hasn't been run, advisory only (always exits 0)
+- [ ] **7.2** Write `hooks/hooks.json`: PostToolUse hook for Bash targeting release readiness check script
+- [ ] **7.3** Propagate `check-gh-cli.sh` copies: `changelog/scripts/` → `release-ready/scripts/`, `tag-release/scripts/`, `release-plan/scripts/` (3 additional copies, 4 total within plugin)
+- [ ] **7.4** Implement `scripts/check-template-drift.sh`: verify all `check-gh-cli.sh` copies match principled-github canonical source (cross-plugin drift detection)
+- [ ] **7.5** Write plugin `README.md`: installation, skills table, hook, changelog format, release workflow, version bump heuristics, drift detection
+- [ ] **7.6** Update `.github/workflows/ci.yml`: add principled-release drift check step
+- [ ] **7.7** Update root `CLAUDE.md`: add principled-release to architecture table, skills table, conventions, hooks, testing, dogfooding, dependencies
+- [ ] **7.8** Update `.claude/CLAUDE.md`: add principled-release dogfooding section and common pitfalls
+
+---
+
+## Decisions Required
+
+Architectural decisions resolved before implementation:
+
+1. **Changelog generation source.** → ADR-013: Pipeline-based changelog generation from proposals, plans, and ADRs rather than commit messages.
+2. **Cross-plugin script sharing.** → Copy with cross-plugin drift check. Canonical stays in principled-github (same pattern as principled-quality).
+3. **Release scope boundary.** → Plugin stops at tag and release notes. No deployment, environment promotion, or rollback.
+
+Open decisions to resolve during implementation:
+
+1. **Changelog file persistence.** Should `/changelog` write to `CHANGELOG.md` or only output to stdout? If written, single root file or per-module?
+2. **Pre-release version support.** Include `--pre <label>` in v0.1.0 or defer?
+3. **Release branch workflow.** Should `/release-plan` create a branch or assume the team's strategy?
+
+---
+
+## Dependencies
+
+| Dependency                           | Required By                           | Status          |
+| ------------------------------------ | ------------------------------------- | --------------- |
+| gh CLI (installed and authenticated) | changelog, release-ready, tag-release | Required        |
+| Git                                  | All skills (log, tag, history)        | Available       |
+| Bash shell                           | All scripts                           | Available       |
+| jq (optional, with grep fallback)    | JSON parsing in scripts               | Optional        |
+| principled-docs document format      | Frontmatter parsing, status checks    | Stable (v0.3.1) |
+| principled-github check-gh-cli.sh    | Cross-plugin drift canonical          | Stable (v0.1.0) |
+| principled-github /pr-describe       | PR reference generation (conceptual)  | Stable (v0.1.0) |
+| Marketplace structure (RFC-002)      | Plugin location                       | Complete        |
+
+---
+
+## Acceptance Criteria
+
+- [ ] `/changelog --since v0.3.1` generates changelog entries grouped by Features, Improvements, Decisions, and Uncategorized
+- [ ] `/changelog --since v0.3.1 --module plugins/principled-docs` scopes to a single module
+- [ ] Changelog entries include parenthetical pipeline references (e.g., "(RFC-001, Plan-001)")
+- [ ] Changes without pipeline references appear under "Uncategorized" (not hidden)
+- [ ] `/release-ready` reports pass/fail for each referenced pipeline document
+- [ ] `/release-ready --strict` exits non-zero when any referenced document is not in terminal status
+- [ ] `/version-bump --module <path>` detects the version manifest and applies the bump
+- [ ] `/version-bump --type major` overrides automatic bump detection
+- [ ] `/release-plan --since v0.3.1` generates a reviewable release plan document
+- [ ] `/tag-release 0.4.0 --dry-run` shows what would happen without creating a tag
+- [ ] `/tag-release 0.4.0` creates a git tag and generates release notes
+- [ ] `check-release-readiness.sh` warns when `git tag` is detected without prior readiness check (advisory, never blocks)
+- [ ] `check-template-drift.sh` passes when all cross-plugin `check-gh-cli.sh` copies match canonical
+- [ ] `check-template-drift.sh` fails when any copy diverges
+- [ ] Plugin README documents all skills, hook, changelog format, and release workflow


### PR DESCRIPTION
## Summary

- **ADR-013**: Pipeline-based changelog generation — changelogs synthesized from proposals, plans, and ADRs rather than commit messages
- **Architecture doc**: `release-system.md` — release lifecycle, change mapping, readiness checks, version bump heuristics
- **Plan-006**: DDD implementation plan with 6 bounded contexts, 7 phases, 27 tasks covering the full principled-release plugin build

## Test plan

- [x] All 3 files pass markdownlint
- [x] All 3 files pass Prettier formatting
- [ ] Verify ADR frontmatter follows conventions (number, status, from_proposal)
- [ ] Verify plan references correct ADR and proposal numbers
- [ ] Verify architecture doc references correct related_adrs

🤖 Generated with [Claude Code](https://claude.com/claude-code)