### PR TITLE
fix: resolve plugin infrastructure gaps and documentation incoherencies

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,38 +4,7 @@ This file supplements the root `CLAUDE.md` with development-specific guidance fo
 
 ## Dogfooding
 
-This repo installs all four first-party plugins (via `.claude/settings.json`). This means:
-
-### principled-docs
-
-- All 9 plugin skills (`/scaffold`, `/validate`, `/new-proposal`, `/new-plan`, `/new-adr`, `/new-architecture-doc`, `/proposal-status`, `/docs-audit`) are available as slash commands
-- All enforcement hooks (ADR immutability, proposal lifecycle, structure nudge) are active
-- Use the plugin's own skills to manage the marketplace's `docs/` directory
-
-### principled-implementation
-
-- All 6 plugin skills (`/decompose`, `/spawn`, `/check-impl`, `/merge-work`, `/orchestrate`) are available as slash commands
-- The `impl-worker` agent is available for worktree-isolated task execution
-- The manifest integrity advisory hook is active
-- Use `/orchestrate` against DDD plans in `docs/plans/` to execute implementation tasks
-
-### principled-github
-
-- All 9 plugin skills (`/triage`, `/ingest-issue`, `/sync-issues`, `/pr-describe`, `/gh-scaffold`, `/gen-codeowners`, `/sync-labels`, `/pr-check`) are available as slash commands
-- The PR reference advisory hook is active
-- Use `/triage` to batch-process all open untriaged issues into the principled pipeline
-- Use `/ingest-issue` to pull a single GitHub issue into the pipeline (normalizes metadata, creates proposals/plans)
-- Use `/sync-issues` to push proposals/plans to GitHub issues
-- Use `/gh-scaffold` to set up `.github/` directory with principled-aligned templates
-
-### principled-quality
-
-- All 5 plugin skills (`/review-checklist`, `/review-context`, `/review-coverage`, `/review-summary`) are available as slash commands
-- The review checklist advisory hook is active
-- Use `/review-checklist` to generate spec-driven review checklists for PRs
-- Use `/review-context` to surface relevant specifications for a PR's changed files
-- Use `/review-coverage` to assess review completeness against checklist items
-- Use `/review-summary` to generate structured review summaries
+All four first-party plugins are installed via `.claude/settings.json`. See root `CLAUDE.md` § Dogfooding for the full list of available skills and active hooks.
 
 ## Common Pitfalls
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,8 +24,5 @@
     "principled-implementation@principled-marketplace": true,
     "principled-github@principled-marketplace": true,
     "principled-quality@principled-marketplace": true
-  },
-  "env": {
-    "CLAUDE_PLUGIN_ROOT": "./plugins/principled-docs"
   }
 }

--- a/.claude/skills/check-ci/SKILL.md
+++ b/.claude/skills/check-ci/SKILL.md
@@ -58,31 +58,51 @@ bash plugins/principled-docs/skills/scaffold/scripts/check-template-drift.sh
 bash plugins/principled-implementation/scripts/check-template-drift.sh
 ```
 
-### 7. Root Structure Validation (validate)
+### 7. Template Drift — principled-github (validate)
+
+```bash
+bash plugins/principled-github/scripts/check-template-drift.sh
+```
+
+### 8. Template Drift — principled-quality (validate)
+
+```bash
+bash plugins/principled-quality/scripts/check-template-drift.sh
+```
+
+### 9. Root Structure Validation (validate)
 
 ```bash
 bash plugins/principled-docs/skills/scaffold/scripts/validate-structure.sh --root
 ```
 
-### 8. Marketplace Manifest Validation (validate)
+### 10. Marketplace Manifest Validation (validate)
 
 Verify `.claude-plugin/marketplace.json` is valid JSON and all plugin source directories exist.
 
-### 9. Plugin Manifest Validation (validate)
+### 11. Plugin Manifest Validation (validate)
 
 Verify every plugin in `plugins/*/` and `external_plugins/*/` has a valid `.claude-plugin/plugin.json`.
 
-### 10. Smoke-test ADR Immutability Hook (validate)
+### 12. Smoke-test ADR Immutability Hook (validate)
 
 For each `docs/decisions/*.md` with `status: accepted`, feed its path to `check-adr-immutability.sh` and verify exit code 2 (block). Also test a non-decision file and verify exit code 0 (allow).
 
-### 11. Smoke-test Proposal Lifecycle Hook (validate)
+### 13. Smoke-test Proposal Lifecycle Hook (validate)
 
 For each `docs/proposals/*.md` with terminal status, feed its path to `check-proposal-lifecycle.sh` and verify exit code 2. For draft proposals, verify exit code 0.
 
-### 12. Smoke-test Manifest Integrity Hook (validate)
+### 14. Smoke-test Manifest Integrity Hook (validate)
 
 Feed `.impl/manifest.json` path to `check-manifest-integrity.sh` and verify exit code 0 (advisory). Feed an unrelated path and verify exit code 0 (silent passthrough).
+
+### 15. Smoke-test PR Reference Hook (validate)
+
+Feed `gh pr create --title "test" --body "test"` command to `check-pr-references.sh` and verify exit code 0 (advisory). Feed an unrelated command and verify exit code 0 (silent passthrough).
+
+### 16. Smoke-test Review Checklist Hook (validate)
+
+Feed `gh pr review 42` and `gh pr merge 42` commands to `check-review-checklist.sh` and verify exit code 0 (advisory). Feed an unrelated command and verify exit code 0 (silent passthrough).
 
 ### Summary
 

--- a/.claude/skills/propagate-templates/SKILL.md
+++ b/.claude/skills/propagate-templates/SKILL.md
@@ -52,11 +52,33 @@ Copy each canonical script to its consuming skills:
 
 1. `plugins/principled-implementation/skills/spawn/templates/claude-task.md` → `plugins/principled-implementation/skills/orchestrate/templates/claude-task.md`
 
+### principled-github — Script Propagation
+
+Copy each canonical script to its consuming skills:
+
+1. `plugins/principled-github/skills/sync-issues/scripts/check-gh-cli.sh` → `plugins/principled-github/skills/sync-labels/scripts/check-gh-cli.sh`
+2. `plugins/principled-github/skills/sync-issues/scripts/check-gh-cli.sh` → `plugins/principled-github/skills/pr-check/scripts/check-gh-cli.sh`
+3. `plugins/principled-github/skills/sync-issues/scripts/check-gh-cli.sh` → `plugins/principled-github/skills/gh-scaffold/scripts/check-gh-cli.sh`
+4. `plugins/principled-github/skills/sync-issues/scripts/check-gh-cli.sh` → `plugins/principled-github/skills/ingest-issue/scripts/check-gh-cli.sh`
+5. `plugins/principled-github/skills/sync-issues/scripts/check-gh-cli.sh` → `plugins/principled-github/skills/triage/scripts/check-gh-cli.sh`
+6. `plugins/principled-github/skills/sync-issues/scripts/check-gh-cli.sh` → `plugins/principled-github/skills/pr-describe/scripts/check-gh-cli.sh`
+
+### principled-quality — Cross-Plugin Script Propagation
+
+Copy from the principled-github canonical source to principled-quality skills:
+
+1. `plugins/principled-github/skills/sync-issues/scripts/check-gh-cli.sh` → `plugins/principled-quality/skills/review-checklist/scripts/check-gh-cli.sh`
+2. `plugins/principled-github/skills/sync-issues/scripts/check-gh-cli.sh` → `plugins/principled-quality/skills/review-context/scripts/check-gh-cli.sh`
+3. `plugins/principled-github/skills/sync-issues/scripts/check-gh-cli.sh` → `plugins/principled-quality/skills/review-coverage/scripts/check-gh-cli.sh`
+4. `plugins/principled-github/skills/sync-issues/scripts/check-gh-cli.sh` → `plugins/principled-quality/skills/review-summary/scripts/check-gh-cli.sh`
+
 ### Verification
 
-Run both drift checks:
+Run all four drift checks:
 
 1. `bash plugins/principled-docs/skills/scaffold/scripts/check-template-drift.sh`
 2. `bash plugins/principled-implementation/scripts/check-template-drift.sh`
+3. `bash plugins/principled-github/scripts/check-template-drift.sh`
+4. `bash plugins/principled-quality/scripts/check-template-drift.sh`
 
 Confirm all copies are byte-identical to their canonical sources. Report the result per plugin: PASS (zero drift) or FAIL (list drifted files).

--- a/.claude/skills/test-hooks/SKILL.md
+++ b/.claude/skills/test-hooks/SKILL.md
@@ -1,16 +1,17 @@
 ---
 name: test-hooks
 description: >
-  Smoke-test the enforcement hooks by feeding known good and bad inputs
+  Smoke-test all enforcement hooks by feeding known good and bad inputs
   and verifying exit codes. Tests the ADR immutability guard, the
-  proposal lifecycle guard, and the manifest integrity advisory.
+  proposal lifecycle guard, the manifest integrity advisory, the PR
+  reference advisory, and the review checklist advisory.
 allowed-tools: Bash(echo *), Bash(bash plugins/*), Read
 user-invocable: true
 ---
 
 # Test Hooks — Enforcement Hook Smoke Tests
 
-Smoke-test the enforcement hooks by feeding known good and bad inputs and verifying exit codes.
+Smoke-test all enforcement hooks by feeding known good and bad inputs and verifying exit codes.
 
 ## Command
 
@@ -94,6 +95,62 @@ Run these test cases:
    ```
 
    Expected: exit code 0 (guard scripts default to allow).
+
+### PR Reference Advisory (`plugins/principled-github/hooks/scripts/check-pr-references.sh`)
+
+Run these test cases:
+
+1. **`gh pr create` command — should warn but allow (exit 0):**
+
+   ```bash
+   echo '{"tool_input":{"command":"gh pr create --title \"test\" --body \"test\""}}' | bash plugins/principled-github/hooks/scripts/check-pr-references.sh
+   ```
+
+   Expected: exit code 0, with advisory message on stderr.
+
+2. **Unrelated command — should pass silently (exit 0):**
+
+   ```bash
+   echo '{"tool_input":{"command":"git status"}}' | bash plugins/principled-github/hooks/scripts/check-pr-references.sh
+   ```
+
+   Expected: exit code 0, no output.
+
+3. **Missing JSON input — should allow (exit 0):**
+
+   ```bash
+   echo '{}' | bash plugins/principled-github/hooks/scripts/check-pr-references.sh
+   ```
+
+   Expected: exit code 0 (guard scripts default to allow).
+
+### Review Checklist Advisory (`plugins/principled-quality/hooks/scripts/check-review-checklist.sh`)
+
+Run these test cases:
+
+1. **`gh pr review` command — should warn but allow (exit 0):**
+
+   ```bash
+   echo '{"tool_input":{"command":"gh pr review 42"}}' | bash plugins/principled-quality/hooks/scripts/check-review-checklist.sh
+   ```
+
+   Expected: exit code 0, with advisory message on stderr.
+
+2. **`gh pr merge` command — should warn but allow (exit 0):**
+
+   ```bash
+   echo '{"tool_input":{"command":"gh pr merge 42"}}' | bash plugins/principled-quality/hooks/scripts/check-review-checklist.sh
+   ```
+
+   Expected: exit code 0, with advisory message on stderr.
+
+3. **Unrelated command — should pass silently (exit 0):**
+
+   ```bash
+   echo '{"tool_input":{"command":"git status"}}' | bash plugins/principled-quality/hooks/scripts/check-review-checklist.sh
+   ```
+
+   Expected: exit code 0, no output.
 
 ### Reporting
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,3 +37,17 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+
+      - id: github-template-drift
+        name: github plugin template drift check
+        entry: bash plugins/principled-github/scripts/check-template-drift.sh
+        language: system
+        pass_filenames: false
+        always_run: true
+
+      - id: quality-template-drift
+        name: quality plugin template drift check
+        entry: bash plugins/principled-quality/scripts/check-template-drift.sh
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,15 @@ The `spawn` skill delegates to `impl-worker` via `context: fork` + `agent: impl-
 - `plugins/principled-quality/scripts/check-template-drift.sh` verifies all 4 cross-plugin pairs. Drift = CI failure.
 - This is the first cross-plugin copy in the marketplace. The drift checker navigates to the sibling plugin via `$REPO_ROOT`.
 
+### Cross-Plugin Dependencies
+
+- `task-manifest.sh`: Canonical in `plugins/principled-implementation/skills/decompose/scripts/`. A read-only subset copy exists in `plugins/principled-github/skills/pr-describe/scripts/` for manifest format compatibility. This copy is intentionally different (not byte-identical) and is **not drift-checked** — it maintains only the interface contract for reading task manifests.
+- `check-gh-cli.sh`: Canonical in `plugins/principled-github/skills/sync-issues/scripts/`. Byte-identical copies exist in 4 principled-quality skills. Drift-checked by `plugins/principled-quality/scripts/check-template-drift.sh`.
+
+### Canonical Source Convention
+
+The canonical version of a shared script or template lives in the skill most closely associated with its primary purpose. When adding a new shared script, declare the canonical location in the relevant `check-template-drift.sh` and in `/propagate-templates`.
+
 ### Naming Patterns
 
 - Documents: `NNN-short-title.md` (e.g., `001-switch-to-event-sourcing.md`)
@@ -177,11 +186,11 @@ See `.claude/CLAUDE.md` for development-specific context.
 
 ## Pipeline
 
-Proposals → Decisions → Plans → Implementation.
+Proposals → Plans → Implementation. Decisions (ADRs) at any point.
 
 - **Proposals** are strategic (what/why). Status: `draft → in-review → accepted|rejected|superseded`.
-- **Decisions** are the permanent record. Status: `proposed → accepted → deprecated|superseded`. Immutable after acceptance.
 - **Plans** are tactical (how, via DDD). Status: `active → complete|abandoned`. Require an accepted proposal (`--from-proposal NNN`).
+- **Decisions** are the permanent record of significant choices, created at any point during the pipeline. Status: `proposed → accepted → deprecated|superseded`. Immutable after acceptance.
 - **Implementation** is automated execution. `/orchestrate` decomposes a plan, spawns worktree-isolated agents, validates results, and merges back.
 
 ## Important Constraints

--- a/docs/architecture/documentation-pipeline.md
+++ b/docs/architecture/documentation-pipeline.md
@@ -8,23 +8,28 @@ related_adrs: [002, 003]
 
 ## Purpose
 
-Describes the three-stage documentation pipeline (Proposals → Decisions → Plans) that governs how changes flow from strategic intent through architectural decisions to tactical implementation. Intended for anyone working with the documentation system — authors, reviewers, and maintainers.
+Describes the documentation pipeline that governs how changes flow from strategic intent through tactical implementation, with architectural decisions recorded along the way. Intended for anyone working with the documentation system — authors, reviewers, and maintainers.
 
 ## Overview
 
-Every significant change follows a three-stage pipeline:
+Every significant change follows a pipeline with three document types:
 
 ```
-┌─────────────┐       ┌─────────────┐       ┌─────────────┐
-│  PROPOSAL    │       │  DECISION    │       │    PLAN      │
-│   (RFC)      │──────▶│   (ADR)      │──────▶│   (DDD)      │
-│              │       │              │       │              │
-│ "what & why" │       │ "what was    │       │ "how"        │
-│              │       │  decided"    │       │              │
-└─────────────┘       └─────────────┘       └─────────────┘
-  Strategic             Permanent              Tactical
-  docs/proposals/       docs/decisions/        docs/plans/
+┌─────────────┐                           ┌─────────────┐
+│  PROPOSAL    │                           │    PLAN      │
+│   (RFC)      │──────────────────────────▶│   (DDD)      │
+│              │                           │              │
+│ "what & why" │    ┌─────────────┐        │ "how"        │
+│              │    │  DECISION    │        │              │
+└─────────────┘    │   (ADR)      │        └─────────────┘
+  Strategic        │ "what was    │          Tactical
+  docs/proposals/  │  decided"    │          docs/plans/
+                   └─────────────┘
+                     Permanent
+                     docs/decisions/
 ```
+
+Proposals lead to plans. Decisions (ADRs) are created at any point during the pipeline as permanent records of significant architectural choices. They are not a sequential step between proposals and plans.
 
 Each stage has distinct characteristics:
 
@@ -65,13 +70,13 @@ proposed ──→ accepted ──→ deprecated
 ```
 
 - Immutable after acceptance (one exception: `superseded_by` field)
-- May be standalone or linked to a proposal via `originating_proposal`
-- Acceptance enables plan creation
+- May be standalone or linked to a proposal via `originating_proposal` (canonical field name) or `from_proposal` (legacy equivalent used in ADRs 004-012)
+- Any tooling reading this field must check both `originating_proposal` and `from_proposal`; new ADRs should use `originating_proposal`
 - Referenced by architecture docs
 
 ### Plans (DDD Decompositions)
 
-Plans decompose accepted decisions into concrete implementation work. They use domain-driven development to break down work into bounded contexts, aggregates, domain events, and implementation tasks.
+Plans decompose accepted proposals into concrete implementation work. They use domain-driven development to break down work into bounded contexts, aggregates, domain events, and implementation tasks.
 
 **Lifecycle:**
 
@@ -117,14 +122,14 @@ Architecture Doc (living)
 
 ### Cross-Referencing
 
-| Document         | Links To                        | Via                                                  |
-| ---------------- | ------------------------------- | ---------------------------------------------------- |
-| ADR              | Originating proposal (optional) | `originating_proposal` frontmatter                   |
-| ADR              | Superseded ADR                  | `superseded_by` on old ADR                           |
-| Plan             | Originating proposal            | `originating_proposal` frontmatter + markdown link   |
-| Plan             | Related ADRs                    | `related_adrs` frontmatter + "Related Decisions"     |
-| Architecture doc | Related ADRs                    | `related_adrs` frontmatter + "Key Decisions" section |
-| Proposal         | Superseding proposal            | `superseded_by` frontmatter                          |
+| Document         | Links To                        | Via                                                                                         |
+| ---------------- | ------------------------------- | ------------------------------------------------------------------------------------------- |
+| ADR              | Originating proposal (optional) | `originating_proposal` or `from_proposal` frontmatter (`originating_proposal` is canonical) |
+| ADR              | Superseded ADR                  | `superseded_by` on old ADR                                                                  |
+| Plan             | Originating proposal            | `originating_proposal` frontmatter + markdown link                                          |
+| Plan             | Related ADRs                    | `related_adrs` frontmatter + "Related Decisions"                                            |
+| Architecture doc | Related ADRs                    | `related_adrs` frontmatter + "Key Decisions" section                                        |
+| Proposal         | Superseding proposal            | `superseded_by` frontmatter                                                                 |
 
 ### Scope: Module vs. Root
 
@@ -155,10 +160,11 @@ Both scopes use identical conventions, templates, lifecycle rules, and naming pa
 4. Author creates ADR for the key decision
    → docs/decisions/001-use-kafka-for-event-store.md (status: proposed → accepted)
 
-5. Author creates DDD plan from the accepted ADR
+5. Author creates DDD plan from the accepted proposal
    → docs/plans/001-switch-to-event-sourcing.md (status: active)
    → Bounded contexts, aggregates, domain events defined
    → Implementation tasks listed
+   → References related ADRs via related_adrs field
 
 6. Plan completed
    → Plan status: complete

--- a/plugins/principled-docs/skills/scaffold/scripts/check-template-drift.sh
+++ b/plugins/principled-docs/skills/scaffold/scripts/check-template-drift.sh
@@ -32,7 +32,10 @@ compare() {
   fi
 
   if ! diff -q "$canonical" "$copy" > /dev/null 2>&1; then
-    echo "DRIFT: $copy differs from $canonical"
+    echo "DRIFT: Copy has diverged from canonical."
+    echo "  Canonical: $canonical"
+    echo "  Copy:      $copy"
+    echo "  Fix: run /propagate-templates"
     DRIFTED=$((DRIFTED + 1))
   fi
 }

--- a/plugins/principled-github/scripts/check-template-drift.sh
+++ b/plugins/principled-github/scripts/check-template-drift.sh
@@ -40,7 +40,10 @@ compare() {
   fi
 
   if ! diff -q "$canonical" "$copy" > /dev/null 2>&1; then
-    echo "DRIFT: $copy differs from $canonical"
+    echo "DRIFT: Copy has diverged from canonical."
+    echo "  Canonical: $canonical"
+    echo "  Copy:      $copy"
+    echo "  Fix: run /propagate-templates"
     DRIFTED=$((DRIFTED + 1))
   fi
 }

--- a/plugins/principled-implementation/scripts/check-template-drift.sh
+++ b/plugins/principled-implementation/scripts/check-template-drift.sh
@@ -32,7 +32,10 @@ compare() {
   fi
 
   if ! diff -q "$canonical" "$copy" > /dev/null 2>&1; then
-    echo "DRIFT: $copy differs from $canonical"
+    echo "DRIFT: Copy has diverged from canonical."
+    echo "  Canonical: $canonical"
+    echo "  Copy:      $copy"
+    echo "  Fix: run /propagate-templates"
     DRIFTED=$((DRIFTED + 1))
   fi
 }

--- a/plugins/principled-quality/scripts/check-template-drift.sh
+++ b/plugins/principled-quality/scripts/check-template-drift.sh
@@ -41,7 +41,10 @@ compare() {
   fi
 
   if ! diff -q "$canonical" "$copy" > /dev/null 2>&1; then
-    echo "DRIFT: $copy differs from $canonical"
+    echo "DRIFT: Copy has diverged from canonical."
+    echo "  Canonical: $canonical"
+    echo "  Copy:      $copy"
+    echo "  Fix: run /propagate-templates"
     DRIFTED=$((DRIFTED + 1))
   fi
 }


### PR DESCRIPTION
## Summary

- **Remove hardcoded `CLAUDE_PLUGIN_ROOT` env override** — the global var in `.claude/settings.json` pointed only to principled-docs, causing 3 of 4 plugins' hooks to resolve to nonexistent scripts
- **Add missing drift checks to pre-commit** — principled-github and principled-quality were only checked in CI, not locally
- **Complete dev skills** — `/propagate-templates`, `/test-hooks`, and `/check-ci` now cover all 4 plugins and all 5 hooks
- **Improve drift check error messages** — all 4 `check-template-drift.sh` scripts now identify canonical vs copy paths and suggest `/propagate-templates`
- **Fix pipeline order documentation** — corrected "Proposals → Decisions → Plans" to the actual enforced flow: Proposals → Plans → Implementation, with Decisions (ADRs) at any point
- **Document ADR field name split** — `originating_proposal` (canonical) vs `from_proposal` (legacy, ADRs 004-012) now documented as equivalent
- **Document cross-plugin dependencies and canonical source convention** in root `CLAUDE.md`
- **Trim `.claude/CLAUDE.md` redundancy** — replaced duplicated dogfooding section with reference to root

## Test plan

- [x] All 4 drift checks pass
- [x] Markdown lint: 0 errors
- [x] Prettier: all files formatted
- [ ] `pre-commit run --all-files` — should now check all 4 plugins' drift
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)