### PR TITLE
docs: split RFC-010 into three proposals; accept ADR-017 and ADR-018

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,6 +201,10 @@ All pipeline documents (proposals, plans, decisions) use YAML frontmatter betwee
 This repo uses its own documentation pipeline at the root level (governing the marketplace):
 
 - `docs/proposals/` — RFCs. RFC-000 is the plugin's own PRD. RFC-002 established the marketplace.
+  - RFC-010 (multi-agent orchestration) is `superseded`: it covered seven systems in
+    one document and was split into RFC-011 (agent memory and resumability), RFC-012
+    (GitHub-native collaboration and autonomous execution), and RFC-013 (self-improvement
+    loop). RFC-010 is retained as the strategic vision.
 - `docs/plans/` — DDD implementation plans. Plan-000 tracks the plugin build.
 - `docs/decisions/` — ADRs (immutable after acceptance).
   - 001: Pure bash frontmatter parsing strategy
@@ -219,6 +223,8 @@ This repo uses its own documentation pipeline at the root level (governing the m
   - 014: Heuristic architecture governance
   - 015: Event-driven lifecycle hooks for pipeline enforcement
   - 016: Agent teams for parallel plan execution
+  - 017: Event log as record, SQLite as cache (principled-tasks storage)
+  - 018: Shared plugin `lib/` over copy-with-drift-detection (supersedes 009)
 - `docs/architecture/` — Living design docs.
   - plugin-system.md, documentation-pipeline.md, enforcement-system.md
 
@@ -275,7 +281,7 @@ Proposals → Plans → Implementation. Decisions (ADRs) at any point.
 ## Important Constraints
 
 - **Proposals** with terminal status (`accepted`, `rejected`, `superseded`) must NOT be modified. Enforced by `check-proposal-lifecycle.sh`.
-- **ADRs** with status `accepted` must NOT be modified, except the `superseded_by` field. Enforced by `check-adr-immutability.sh`.
+- **ADRs** with status `accepted` must NOT be modified, except to record supersession: the `superseded_by` field, the `status` transition to `superseded`, and a pointer in the Status section. The reasoning body stays as written. Enforced by `check-adr-immutability.sh`; the chain is validated by `scripts/pipeline-audit.sh`.
 - **Plans** require an accepted proposal (`--from-proposal NNN`). Enforced by `check-plan-proposal-link.sh`.
 - **Pipeline documents** must have valid frontmatter. Enforced by `check-required-frontmatter.sh`.
 - **Document numbers** must be unique within their directory. Enforced by `check-doc-numbering.sh`.

--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ A Claude Code plugin marketplace hosting first-party and community plugins for t
 
 ### First-Party
 
-| Plugin                                                                       | Category       | Description                                                                                                                         |
-| ---------------------------------------------------------------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| [**principled-docs**](plugins/principled-docs/README.md)                     | documentation  | Scaffold, author, and enforce module documentation structure following the Principled specification-first methodology (v0.3.1)      |
-| [**principled-implementation**](plugins/principled-implementation/README.md) | implementation | Orchestrate DDD plan execution via worktree-isolated Claude Code agents (v0.1.0)                                                    |
-| [**principled-github**](plugins/principled-github/README.md)                 | workflow       | Integrate the principled workflow with GitHub native features: issues, PRs, templates, actions, CODEOWNERS, and labels (v0.1.0)     |
-| [**principled-quality**](plugins/principled-quality/README.md)               | quality        | Connect code reviews to the principled documentation pipeline with spec-driven checklists and review tracking (v0.1.0)              |
-| [**principled-release**](plugins/principled-release/README.md)               | workflow       | Generate changelogs from the documentation pipeline, verify release readiness, and coordinate versioned releases (v0.1.0)           |
-| [**principled-architecture**](plugins/principled-architecture/README.md)     | architecture   | Map modules to governing ADRs, detect architectural drift, audit governance coverage, and sync architecture docs (v0.1.0)           |
-| [**principled-tasks**](plugins/principled-tasks/README.md)                   | workflow       | Persistent, graph-linked task tracking with SQLite — open, close, query, audit, and visualize tasks across agent workflows (v0.1.0) |
+| Plugin                                                                       | Category       | Description                                                                                                                        |
+| ---------------------------------------------------------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| [**principled-docs**](plugins/principled-docs/README.md)                     | documentation  | Scaffold, author, and enforce module documentation structure following the Principled specification-first methodology (v0.3.1)     |
+| [**principled-implementation**](plugins/principled-implementation/README.md) | implementation | Orchestrate DDD plan execution via worktree-isolated Claude Code agents (v0.1.0)                                                   |
+| [**principled-github**](plugins/principled-github/README.md)                 | workflow       | Integrate the principled workflow with GitHub native features: issues, PRs, templates, actions, CODEOWNERS, and labels (v0.1.0)    |
+| [**principled-quality**](plugins/principled-quality/README.md)               | quality        | Connect code reviews to the principled documentation pipeline with spec-driven checklists and review tracking (v0.1.0)             |
+| [**principled-release**](plugins/principled-release/README.md)               | workflow       | Generate changelogs from the documentation pipeline, verify release readiness, and coordinate versioned releases (v0.1.0)          |
+| [**principled-architecture**](plugins/principled-architecture/README.md)     | architecture   | Map modules to governing ADRs, detect architectural drift, audit governance coverage, and sync architecture docs (v0.1.0)          |
+| [**principled-tasks**](plugins/principled-tasks/README.md)                   | workflow       | Git-native, graph-linked task tracking backed by an append-only event log — merges cleanly across parallel agent branches (v0.1.0) |
 
 ### Community
 

--- a/docs/decisions/009-script-duplication-across-implementation-skills.md
+++ b/docs/decisions/009-script-duplication-across-implementation-skills.md
@@ -1,20 +1,27 @@
 ---
 title: "Script Duplication Across Implementation Skills"
 number: "009"
-status: accepted
+status: superseded
 author: Alex
 created: 2026-02-22
-updated: 2026-02-22
+updated: 2026-07-28
 from_proposal: "006"
 supersedes: null
-superseded_by: null
+superseded_by: "018"
 ---
 
 # ADR-009: Script Duplication Across Implementation Skills
 
 ## Status
 
-Accepted
+Superseded by [ADR-018](018-shared-plugin-lib-over-copies.md).
+
+The reasoning below is retained as the historical record. It is no longer current
+guidance: shared code now lives in each plugin's `lib/` and is referenced via
+`${CLAUDE_PLUGIN_ROOT}`. In practice this decision produced 15 copies of one 31-line
+script, 3,382 redundant lines across `plugins/` (20% of the tree), six drift checkers,
+and a drift checker that silently missed an already-diverged copy. ADR-018 records the
+measurements.
 
 <!-- Valid values: proposed, accepted, deprecated, superseded -->
 <!-- Once accepted, this document is IMMUTABLE. -->

--- a/docs/decisions/017-event-log-task-graph.md
+++ b/docs/decisions/017-event-log-task-graph.md
@@ -1,7 +1,7 @@
 ---
 title: "Event Log as Record, SQLite as Cache"
 number: "017"
-status: proposed
+status: accepted
 author: Alex
 created: 2026-02-27
 updated: 2026-07-28
@@ -14,7 +14,7 @@ superseded_by: null
 
 ## Status
 
-Proposed
+Accepted
 
 <!-- Valid values: proposed, accepted, deprecated, superseded -->
 <!-- Once accepted, this document is IMMUTABLE. -->

--- a/docs/decisions/018-shared-plugin-lib-over-copies.md
+++ b/docs/decisions/018-shared-plugin-lib-over-copies.md
@@ -1,7 +1,7 @@
 ---
 title: "Shared Plugin lib/ Over Copy-With-Drift-Detection"
 number: "018"
-status: proposed
+status: accepted
 author: Alex
 created: 2026-07-28
 updated: 2026-07-28
@@ -13,7 +13,7 @@ superseded_by: null
 
 ## Status
 
-Proposed
+Accepted
 
 <!-- Valid values: proposed, accepted, deprecated, superseded -->
 <!-- Once accepted, this document is IMMUTABLE. -->

--- a/docs/proposals/010-multi-agent-orchestration-at-scale.md
+++ b/docs/proposals/010-multi-agent-orchestration-at-scale.md
@@ -1,15 +1,35 @@
 ---
 title: "Multi-Agent Orchestration at Scale"
 number: "010"
-status: draft
+status: superseded
 author: Alex
 created: 2026-02-23
-updated: 2026-02-23
+updated: 2026-07-28
 supersedes: null
-superseded_by: null
+superseded_by: "011"
 ---
 
 # RFC-010: Multi-Agent Orchestration at Scale
+
+> **Superseded.** This proposal has been split into three independently reviewable and
+> deliverable proposals. It is retained as the strategic vision and as the record of how
+> the systems relate; it is no longer the thing to implement against.
+>
+> | Proposal                                            | Covers          | Depends on                 |
+> | --------------------------------------------------- | --------------- | -------------------------- |
+> | [RFC-011](011-agent-memory-and-resumability.md)     | Systems 1, 2, 6 | Nothing new                |
+> | [RFC-012](012-github-native-agent-collaboration.md) | Systems 3, 4    | RFC-011, RFC-008 (partial) |
+> | [RFC-013](013-agent-self-improvement-loop.md)       | System 5        | RFC-011, RFC-012           |
+>
+> System 7 (the `principled-agent` plugin) is distributed across all three: each
+> declares what it contributes.
+>
+> **Two things changed in the split.** The `.agents/backlog.json` proposed here is
+> withdrawn — principled-tasks (ADR-017) already provides a git-committed work queue
+> with dependency edges. And the rejection of "JSONL + SQLite" as a memory format is
+> revisited in RFC-011, since ADR-017 shipped exactly that pattern for the task graph;
+> the conclusion is that memory and the task graph are different kinds of state, and
+> both rejections were right for their own case.
 
 ## Audience
 

--- a/docs/proposals/011-agent-memory-and-resumability.md
+++ b/docs/proposals/011-agent-memory-and-resumability.md
@@ -1,0 +1,295 @@
+---
+title: "Agent Memory, Identity, and Resumability"
+number: "011"
+status: draft
+author: Alex
+created: 2026-07-28
+updated: 2026-07-28
+supersedes: null
+superseded_by: null
+---
+
+# RFC-011: Agent Memory, Identity, and Resumability
+
+## Audience
+
+- Engineers running `/orchestrate` across sessions who lose reasoning context on every restart
+- Maintainers of principled-implementation, whose manifest schema this extends
+- Anyone evaluating whether agent "memory" is a real capability or a marketing term
+
+## Context
+
+This is the first of three proposals carved out of RFC-010, which covered seven
+systems in one document and was too large to review or deliver. RFC-010 remains the
+strategic vision; this proposal is the foundation the other two build on.
+
+### The problem
+
+Agents start fresh every session. The manifest (ADR-008) tracks _what_ state each task
+is in, but not _why_ — the orchestrator's reasoning, the approaches already tried, the
+review feedback already received. When a session ends, that evaporates.
+
+Three concrete symptoms:
+
+1. **No accumulated knowledge.** An `impl-worker` that learned this codebase uses
+   barrel exports relearns it on the next task, and the one after that.
+2. **No resumability of reasoning.** `--continue` reads task state and resumes
+   mechanically, but a new session cannot know that task 2b already failed twice on
+   the test suite and why.
+3. **All-or-nothing task retry.** A task 80% complete when a session dies restarts
+   from zero, because the manifest has no sub-task visibility.
+
+### What already exists
+
+- **Worktree isolation (ADR-007)** — worktrees survive session death; the filesystem
+  state is already durable.
+- **Manifest-driven state (ADR-008)** — task lifecycle is already tracked and already
+  resumable at task granularity.
+- **principled-tasks (ADR-017)** — an append-only, git-committed task graph with typed
+  dependency edges, agent assignment, and discovery provenance.
+
+That last one matters for scope. RFC-010 assumed it would have to build a shared
+backlog. principled-tasks shipped one. **This proposal therefore covers agent state
+only — properties of the worker, not of the work.** Work tracking is delegated to
+principled-tasks.
+
+## Proposal
+
+Three related additions, all git-native and all backward-compatible.
+
+### 1. Persistent agent identity and memory
+
+A git-committed `.agents/` directory at the repository root:
+
+```
+.agents/
+  registry.json                    # Agent identity registry (queryable metadata)
+  memory/
+    global.md                      # Learnings that apply to every agent
+    agents/
+      impl-worker.md               # Per-agent accumulated knowledge
+      issue-ingester.md
+      pr-reviewer.md
+  retrospectives/
+    2026-07-28-plan-008.md         # Post-execution retrospective
+```
+
+Memory files use **YAML frontmatter plus a markdown body**, consistent with every
+other pipeline document. Frontmatter carries queryable metadata (session count,
+success rate, specializations); the body carries knowledge the LLM consumes directly.
+
+```markdown
+---
+agent_id: "impl-worker"
+role: worker
+last_updated: 2026-07-28
+session_count: 12
+total_tasks: 47
+success_rate: 0.91
+specializations: ["bash", "hook-authoring"]
+---
+
+# impl-worker — Accumulated Knowledge
+
+## Known Patterns
+
+- Shared scripts live in each plugin's `lib/`, referenced via
+  `${CLAUDE_PLUGIN_ROOT}` (ADR-018). Never copy one into a skill directory.
+- macOS ships bash 3.2. No `declare -A`, no `local -n`, no `grep -P`.
+```
+
+**Not every agent gets memory.** Only agents spawned repeatedly for substantively
+similar work accumulate anything useful:
+
+| Agent              | Memory? | Rationale                                                         |
+| ------------------ | :-----: | ----------------------------------------------------------------- |
+| `impl-worker`      |   Yes   | Primary beneficiary — implementation patterns, codebase knowledge |
+| `issue-ingester`   |   Yes   | Triage and classification patterns accumulate                     |
+| `pr-reviewer`      |   Yes   | Learns recurring review themes                                    |
+| `module-auditor`   |   No    | Runs a deterministic script; nothing to learn                     |
+| `decision-auditor` |   No    | Checks supersession chains deterministically                      |
+| `boundary-checker` |   No    | Scans imports against fixed rules                                 |
+
+Memory files are **committed to git**, unlike `.claude/agent-memory/` which is
+gitignored. They are shared team knowledge, not session-local scratch.
+
+### 2. Resumable orchestration
+
+Extend the manifest with a `checkpoint` key — a new top-level field that existing
+manifests simply lack:
+
+```json
+{
+  "plan": "docs/plans/008-example.md",
+  "checkpoint": {
+    "session_id": "sess-abc123",
+    "agent_id": "impl-worker",
+    "phase": 2,
+    "timestamp": "2026-07-28T14:30:00Z",
+    "orchestrator_summary": "Phase 1 complete (3/3 merged). Phase 2: task-2a passed, task-2b failed on the test suite twice — needs a different approach, not a retry. task-2c pending.",
+    "pending_decisions": [
+      "task-2b: response format — envelope vs flat. Blocked on review feedback."
+    ],
+    "environment_state": {
+      "active_worktrees": ["task-2a", "task-2b"],
+      "branches": { "task-2a": "impl/plan-008/task-2a" }
+    }
+  }
+}
+```
+
+The checkpoint carries the **natural-language reasoning** that task state cannot. A
+new session reads it, ingests the summary, and continues.
+
+A new `/resume` skill:
+
+```
+/resume [plan-path] [--from-checkpoint] [--replan]
+```
+
+This is Nondeterministic Idempotence in practice: the path is chaotic (different
+session, different reasoning), but the manifest and checkpoint are deterministic
+anchors, so outcomes converge.
+
+### 3. Checkpointable acceptance criteria
+
+Rather than adding a fourth hierarchy level, make each acceptance criterion
+individually addressable within the existing task model:
+
+```json
+{
+  "id": "2.1",
+  "status": "in_progress",
+  "acceptance_criteria": [
+    {
+      "description": "Middleware rejects missing auth with 401",
+      "verified": true,
+      "verified_at": "2026-07-28T14:20:00Z"
+    },
+    {
+      "description": "Valid tokens pass to next handler",
+      "verified": true,
+      "verified_at": "2026-07-28T14:22:00Z"
+    },
+    {
+      "description": "Unit tests cover both cases",
+      "verified": false,
+      "verified_at": null
+    }
+  ],
+  "estimated_complexity": "medium"
+}
+```
+
+A resumed worker skips verified criteria and continues from the first unverified one.
+
+**What does not change:** the DDD hierarchy stays Plan → Phase → Task (ADR-008),
+`/decompose` keeps its interface, the `impl-worker` contract is unchanged, and
+`/check-impl` still validates at task level.
+
+### Delivery
+
+| Component                      | Plugin                    |
+| ------------------------------ | ------------------------- |
+| `.agents/` structure, registry | principled-agent (new)    |
+| `/resume` skill                | principled-implementation |
+| `inject-agent-memory.sh` hook  | principled-agent          |
+| `check-memory-integrity.sh`    | principled-agent          |
+| Manifest checkpoint field      | principled-implementation |
+| Criterion-level tracking       | principled-implementation |
+
+**No RFC-008 dependency.** Everything here builds on shipped infrastructure.
+
+## Alternatives Considered
+
+### Alternative 1: Pure markdown memory (no frontmatter)
+
+Natural for LLM consumption, but not queryable for routing, metrics, or automated
+pruning. Rejected because the pipeline depends on frontmatter for lifecycle
+enforcement — memory files without it would be second-class documents.
+
+### Alternative 2: Pure JSON or YAML memory
+
+Queryable and structured, but LLMs consume markdown more effectively than nested data
+structures. The primary consumer of memory is the model itself. Rejected.
+
+### Alternative 3: Event log plus SQLite cache, as principled-tasks uses
+
+RFC-010 rejected this outright. That rejection needs revisiting now that ADR-017 has
+shipped exactly this pattern, and the answer is that **the two cases are genuinely
+different**:
+
+|                  | Agent memory                 | Task graph (ADR-017)              |
+| ---------------- | ---------------------------- | --------------------------------- |
+| Primary consumer | The LLM, as prose            | Scripts, as queries               |
+| Access pattern   | Read whole file into context | Filter, aggregate, traverse edges |
+| Write frequency  | Occasionally, after a run    | Every task transition             |
+| Merge pressure   | Low — one file per agent     | High — many agents appending      |
+
+Memory is a _document_; the task graph is a _data structure_. Both are git-native,
+which is the principle that actually matters. Applying an event log to memory would
+buy conflict resistance that memory does not need, at the cost of making the LLM's
+primary input unreadable.
+
+### Alternative 4: Add a fourth hierarchy level (Plan → Phase → Task → Step)
+
+Would give sub-task resumability, but breaks the DDD decomposition contract in ADR-008,
+changes `/decompose`'s output shape, and changes the `impl-worker` contract. Formalizing
+acceptance criteria — which tasks already carry as prose — achieves the same
+granularity with no contract change.
+
+## Consequences
+
+### Positive
+
+- Agents stop relearning the same codebase facts every session
+- A crashed session resumes with reasoning intact, not just task state
+- A task 80% complete resumes at 80%, not zero
+- Memory is reviewable in PRs like any other document — a bad learned pattern is
+  visible and revertable in git history
+- Scope is materially smaller than RFC-010's Phase 1, because work tracking is
+  delegated to principled-tasks rather than rebuilt
+
+### Negative
+
+- `.agents/` is a new committed directory; repositories gain state they must review
+- Memory files grow unboundedly without a pruning strategy (see Open Questions)
+- Injecting memory consumes context budget on every spawn — a large memory file
+  competes with the task description for attention
+- Three manifest consumers (`/check-impl`, `/merge-work`, `/orchestrate`) must all
+  tolerate the new fields
+
+### Risks
+
+- **Learned bad patterns compound.** An agent that records a wrong conclusion will act
+  on it repeatedly. Mitigation: memory changes go through PR review like any document,
+  and RFC-013's regression detection watches for metric degradation after updates.
+- **Memory becomes a dumping ground.** Without curation, files accumulate noise that
+  dilutes useful context. Mitigation: `/improve` (RFC-013) synthesizes rather than
+  appends.
+- **Checkpoint summaries drift from reality.** A summary written by a failing agent may
+  describe a state that does not exist. Mitigation: the checkpoint is advisory context;
+  the manifest remains authoritative for state.
+
+## Architecture Impact
+
+- **New:** `docs/architecture/agent-memory.md` — the `.agents/` contract, memory
+  lifecycle, injection points
+- **Update:** `docs/architecture/documentation-pipeline.md` — retrospectives and memory
+  files as pipeline document types
+- **New ADR:** memory file format (frontmatter + markdown), and why it differs from
+  ADR-017's event log
+- **New ADR:** manifest checkpoint schema, extending ADR-008
+
+## Open Questions
+
+- **Memory pruning.** At what size does a memory file stop helping and start diluting
+  context? Is pruning periodic, size-triggered, or an explicit `/improve` step?
+- **Memory and forks.** Should identity and memory carry across a repository fork?
+  Codebase knowledge transfers; performance metrics probably do not. A reasonable
+  default: memory transfers, registry metrics reset.
+- **Correlating with principled-tasks.** Tasks carry `plan` and `task_id` fields
+  intended to line up with the manifest, but nothing verifies the correspondence.
+  Should `/resume` reconcile the two, and what does it do when they disagree?
+- **Does `.agents/` belong in a new plugin at all**, or should memory live in
+  principled-implementation alongside the manifest it extends?

--- a/docs/proposals/012-github-native-agent-collaboration.md
+++ b/docs/proposals/012-github-native-agent-collaboration.md
@@ -1,0 +1,243 @@
+---
+title: "GitHub-Native Agent Collaboration and Autonomous Execution"
+number: "012"
+status: draft
+author: Alex
+created: 2026-07-28
+updated: 2026-07-28
+supersedes: null
+superseded_by: null
+---
+
+# RFC-012: GitHub-Native Agent Collaboration and Autonomous Execution
+
+## Audience
+
+- Teams who want agents to pick up work from a shared backlog without a human driving each session
+- Reviewers who will receive agent-authored PRs and need to know what guarantees apply
+- Maintainers of principled-github and principled-implementation
+- Anyone assessing the governance risk of letting agents open PRs against their repository
+
+## Context
+
+This is the second of three proposals carved out of RFC-010. RFC-011 covers agent
+memory and resumability; this one covers how agents participate in a GitHub workflow
+and how far they run without a human present.
+
+### The problem
+
+Every orchestration run today requires a human to start it, watch it, and intervene.
+There is no way to hand an agent a backlog and check back later. Humans and agents also
+cannot collaborate through the same surface: agents do not create issues, do not respond
+to review comments, and do not pick up assigned work.
+
+### What already exists
+
+principled-github ships `/triage`, `/ingest-issue`, `/sync-issues`, `/pr-describe`, and
+`/pr-check`. principled-quality ships `/review-checklist`, `/review-context`,
+`/review-coverage`, and `/review-summary`. principled-tasks (ADR-017) ships a shared,
+git-committed task graph with dependency edges and agent assignment.
+
+The pieces of a collaboration loop exist. Nothing composes them into one.
+
+### Dependencies
+
+- **RFC-011 (required).** Dispatch routes work by agent specialization, which lives in
+  the agent registry. Review feedback is written back to agent memory.
+- **RFC-008 (partial).** `interactive` and `supervised` modes need only shipped
+  infrastructure. The four-role parallel model needs agent teams and the lifecycle
+  hooks from Plan-008.
+
+## Proposal
+
+Two layers, deliberately separable: a **protocol** that is portable, and
+**infrastructure** that is swappable.
+
+### 1. The Agent Contributor Protocol
+
+A workflow pattern, not a platform. A team can follow it running agents locally, on
+GitHub Actions, or on any CI system.
+
+```
+1.  Issue assigned to agent (label: agent-ready, assignee: agent ID)
+2.  Agent picks up the issue via /triage
+3.  Agent drafts a proposal via /new-proposal
+4.  Human reviews and approves the proposal
+5.  Agent drafts a plan via /new-plan --from-proposal NNN
+6.  Human reviews and approves the plan
+7.  Agent executes via /orchestrate --mode supervised|autonomous
+8.  Agent self-reviews via /review-checklist
+9.  Agent opens a draft PR via /pr-describe
+10. Human reviews the PR
+11. Agent addresses review comments via /agent-respond
+12. Human merges
+```
+
+The human approval gates at steps 4, 6, 10 and 12 are the point. The agent does the
+work; a human owns every irreversible decision.
+
+**Governance constraints**, following GitHub's own agent-as-collaborator model:
+
+- Agents cannot approve their own PRs
+- Agents open **draft** PRs; promotion to ready-for-review is a human act
+- Agent commits carry co-authorship attribution for audit
+- Protected branch rules apply to agent branches exactly as to human ones
+- Every agent PR links back to its issue, proposal, and plan
+
+**Review feedback loop:** when a human reviews an agent PR, the comments are captured
+via the GitHub API and written into that agent's memory file (RFC-011). Requested
+changes spawn a session to address them. This is the mechanism by which review
+feedback stops being repeated.
+
+### 2. Dispatch infrastructure
+
+GitHub Actions is the first backend, not the only possible one.
+
+`.github/workflows/agent-dispatch.yml`:
+
+1. Triggers on issues labeled `agent-ready`
+2. Dispatches a Claude Code session with the issue context
+3. The agent runs the protocol above
+4. Progress is posted as issue comments
+5. A PR is opened on completion
+6. On failure, an `agent-blocked` issue is created with diagnostics
+
+The backlog is **not** a new data structure. `/triage` assigns issues to agents based
+on specialization and availability from the registry, and the resulting work units are
+tasks in the principled-tasks graph. RFC-010 proposed `.agents/backlog.json`; that is
+withdrawn, because principled-tasks already provides it.
+
+### 3. Execution modes
+
+`/orchestrate` gains a `--mode` flag:
+
+| Mode          | Behavior                                     | Human involvement      |
+| ------------- | -------------------------------------------- | ---------------------- |
+| `interactive` | Current behavior                             | Continuous             |
+| `supervised`  | Runs autonomously, pauses at decision points | At decision gates      |
+| `autonomous`  | Runs end to end, posts results for review    | Post-completion review |
+
+**Supervised mode** posts a progress comment at each phase boundary and continues
+automatically _unless_ a task has exceeded its retry budget (default 2), a decision
+point tagged in the plan is reached, or a phase exceeds 50% task failure — the signal
+that something systemic is wrong rather than one task being hard.
+
+**Autonomous mode** runs decompose → spawn → validate → merge, maintains a live
+progress issue, and finishes by running `/pr-describe`, `/review-checklist`, and
+`/release-ready` before opening a PR. If blocked, it files `agent-blocked` and moves to
+the next available work rather than stalling.
+
+### 4. Parallel execution roles
+
+Building on RFC-008's agent teams:
+
+| Role             | Responsibility                              | Count               |
+| ---------------- | ------------------------------------------- | ------------------- |
+| **Orchestrator** | Decomposes, assigns, monitors               | 1                   |
+| **Workers**      | Execute tasks in isolated worktrees         | N (`--max-workers`) |
+| **Reviewer**     | Pre-validates worker output before merge    | 1                   |
+| **Integrator**   | Manages the merge queue, resolves conflicts | 1                   |
+
+Each role maps to a shipped skill: Workers use `impl-worker`, the Reviewer runs
+`/check-impl` and `/review-checklist`, the Integrator runs `/merge-work`. The roles are
+a coordination pattern over existing capability, not new execution machinery.
+
+This is also where principled-tasks earns its keep: `blocks` edges give the
+Orchestrator a dependency order for free, and the append-only log with a union merge
+driver means N workers on N branches merge their task updates without conflict.
+
+### New skills
+
+| Skill            | Command                                | Description                          |
+| ---------------- | -------------------------------------- | ------------------------------------ |
+| `agent-dispatch` | `/agent-dispatch <issue> [--local]`    | Assign an issue to an agent          |
+| `agent-respond`  | `/agent-respond <pr-number>`           | Address PR review feedback           |
+| `agent-status`   | `/agent-status [--all] [--agent <id>]` | Report workforce status and progress |
+
+`--local` runs dispatch in the current session instead of CI, which makes the entire
+infrastructure layer optional. The protocol is usable with no GitHub Actions at all.
+
+## Alternatives Considered
+
+### Alternative 1: Agents as full collaborators with merge rights
+
+Simpler — no draft-PR dance, no promotion step. Rejected: an agent that can merge its
+own work removes the only reliable check on a non-deterministic system. The cost of the
+extra human step is small; the cost of an unreviewed bad merge is not.
+
+### Alternative 2: A bespoke work queue instead of GitHub issues
+
+More control over scheduling and priority. Rejected because it splits the backlog:
+humans would file issues while agents read a queue, and the two would drift. GitHub
+issues are where the work already is.
+
+### Alternative 3: Build dispatch on a dedicated agent runtime rather than CI
+
+A long-lived agent service would avoid CI cold starts and job time limits. Rejected for
+now as premature — it requires hosting, secrets management, and an availability story,
+none of which a repository plugin should own. The dispatch skill abstracts the runtime
+specifically so this can be revisited.
+
+### Alternative 4: Skip the protocol, ship only execution modes
+
+`--mode autonomous` is the visible feature; the protocol is process. Rejected because
+autonomous execution without governance constraints is the failure mode this proposal
+exists to avoid. The protocol is what makes the modes safe to use.
+
+## Consequences
+
+### Positive
+
+- A human can hand agents a labelled backlog and review results, rather than driving
+  each run
+- Humans and agents collaborate through one surface, with full traceability from issue
+  to proposal to plan to PR
+- Review feedback stops repeating, because it lands in agent memory (RFC-011)
+- The protocol works with no CI infrastructure via `--local`
+- Parallel roles reuse shipped skills rather than introducing new execution machinery
+
+### Negative
+
+- Materially expands the blast radius of an agent mistake: unattended runs can produce
+  many PRs before a human looks
+- GitHub API rate limits become an operational concern under many parallel agents
+- `agent-dispatch.yml` puts Claude Code credentials in CI, which is a secrets-management
+  burden a repository plugin has not previously had
+- Autonomous mode's failure behavior — file `agent-blocked` and move on — can accumulate
+  blocked issues faster than a human triages them
+
+### Risks
+
+- **Runaway loops.** An agent that repeatedly fails, files a blocker, and picks up
+  adjacent work could burn substantial budget. Mitigation: retry budgets, the 50%
+  phase-failure circuit breaker, and a hard cap on concurrent dispatches.
+- **Review fatigue.** If agents open PRs faster than humans review them, the human gate
+  becomes a rubber stamp — which is worse than no gate, because it looks like oversight.
+  Mitigation: cap in-flight agent PRs; treat the queue depth as a health metric.
+- **Credential exposure.** A compromised workflow has repository write access.
+  Mitigation: least-privilege tokens, protected branches, no auto-merge under any mode.
+- **Protocol drift.** Agents may skip steps under `autonomous` mode if the protocol is
+  only documentation. Mitigation: enforce the gates with hooks, not prose.
+
+## Architecture Impact
+
+- **New:** `docs/architecture/agent-collaboration.md` — the contributor protocol,
+  governance constraints, dispatch flow
+- **Update:** `docs/architecture/plugin-system.md` — principled-agent's relationship to
+  principled-github and principled-implementation
+- **New ADR:** GitHub Actions as the first dispatch backend, and what the abstraction
+  boundary is
+- **New ADR:** agent governance constraints (draft PRs, no self-approval, attribution)
+
+## Open Questions
+
+- **Where do the execution modes live?** `--mode` extends `/orchestrate` in
+  principled-implementation, but dispatch and the protocol are principled-agent. Does
+  that split the orchestrator across two plugins?
+- **How is `agent-blocked` triaged?** Autonomous mode can produce blockers faster than
+  they are read. Should there be a blocked-issue budget that halts dispatch?
+- **What is the concurrency ceiling?** RFC-010 cited 20-30 parallel agents from prior
+  art. What does this repository's CI, GitHub API quota, and review capacity actually
+  support?
+- **Does `--mode autonomous` need a kill switch** reachable from outside the session —
+  a label or a file that halts all dispatch?

--- a/docs/proposals/013-agent-self-improvement-loop.md
+++ b/docs/proposals/013-agent-self-improvement-loop.md
@@ -1,0 +1,224 @@
+---
+title: "Agent Self-Improvement Loop"
+number: "013"
+status: draft
+author: Alex
+created: 2026-07-28
+updated: 2026-07-28
+supersedes: null
+superseded_by: null
+---
+
+# RFC-013: Agent Self-Improvement Loop
+
+## Audience
+
+- Engineers who have accumulated conversation histories and reviews that currently feed back into nothing
+- Maintainers deciding whether "self-improving agents" is a capability worth building or a phrase worth avoiding
+- Reviewers who will be asked to approve PRs that change what agents believe
+
+## Context
+
+This is the third of three proposals carved out of RFC-010. RFC-011 provides the
+memory substrate; RFC-012 provides the collaboration surface that generates feedback.
+This proposal closes the loop between them.
+
+### The problem
+
+Performance data exists and is discarded. Manifest outcomes record which tasks failed
+and how often they were retried. PR reviews record what humans corrected. CI records
+what broke. Conversation histories record the reasoning that produced all of it.
+
+None of it changes agent behavior. Every run starts from the same baseline regardless
+of how the last hundred went.
+
+### Why this is separable
+
+RFC-011 gives agents somewhere to remember. RFC-012 gives them a stream of human
+feedback. Neither requires this proposal to be useful — memory can be written by hand,
+and review feedback can be applied by a human. This proposal automates the synthesis,
+which is why it goes last: it is the only one of the three that can act on its own
+conclusions, and that deserves the most scrutiny.
+
+### Dependencies
+
+- **RFC-011 (required).** There is nothing to write to without `.agents/memory/`.
+- **RFC-012 (recommended).** PR review comments are the highest-signal input. Without
+  it, the loop runs on manifest outcomes and CI results alone.
+- **RFC-008: none.**
+
+## Proposal
+
+A closed cycle with an explicit brake:
+
+```
+Execute → Capture → Analyze → Synthesize → Inject → Verify → Execute
+                                                       │
+                                              regression? revert
+```
+
+### 1. Capture
+
+| Source                 | What it captures                         | Where it lives            |
+| ---------------------- | ---------------------------------------- | ------------------------- |
+| Manifest outcomes      | Task success/failure, retry counts       | `.impl/manifest.json`     |
+| Task graph             | Discovery chains, blocked chains, timing | `.principled/tasks.jsonl` |
+| PR review comments     | Human feedback on quality                | GitHub API                |
+| CI results             | Build, test, lint pass rates             | GitHub Actions            |
+| Conversation histories | Full reasoning traces                    | User-provided, local      |
+| Retrospectives         | Synthesized learnings per run            | `.agents/retrospectives/` |
+
+Every orchestration run generates a retrospective document — a pipeline document with
+frontmatter and a structured body, subject to the same hook enforcement as any other.
+
+### 2. Analyze
+
+`/retro [plan-path] [--auto]` processes retrospectives to answer specific questions:
+
+- Which task types consistently fail on first attempt?
+- Which review feedback recurs across PRs?
+- Which areas of the codebase generate the most retries?
+- Which prompt patterns preceded successful runs?
+
+### 3. Synthesize
+
+`/improve [--agent <id>] [--dry-run]` distills findings into memory updates:
+
+- **Global memory** — patterns that apply to every agent
+- **Agent memory** — patterns specific to one role or specialization
+- **Anti-patterns** — approaches to explicitly avoid
+
+`/improve` **synthesizes rather than appends.** This is the difference between memory
+that stays useful and memory that becomes a landfill. `--dry-run` prints the proposed
+diff without writing.
+
+### 4. Ingest conversation history
+
+```
+/ingest-history <path> [--agent <id>] [--extract-patterns]
+```
+
+Conversation histories are the richest available signal and currently the most wasted.
+This extracts successful approaches, recurring errors and their resolutions,
+codebase-specific knowledge, and — most valuable — the points where a human redirected
+the agent.
+
+Histories stay local and are never transmitted; the skill reads them and writes
+distilled patterns into memory.
+
+### 5. Verify, and revert on regression
+
+This is the part that makes the loop safe to run.
+
+```
+/agent-metrics [--agent <id>] [--since <date>]
+```
+
+Reports tasks completed, failed, and retried; average retries by task type; review
+feedback frequency by category; and the trend over time.
+
+**Regression detection:** if metrics degrade after a memory update — higher retry rates,
+more review rejections — the system flags it. Because memory updates are ordinary git
+commits, reverting to the last known-good state is a `git revert`. Without this, a loop
+that can rewrite its own instructions on the basis of its own output will eventually
+drift, and nothing will notice.
+
+### New skills
+
+| Skill            | Command                               | Description                          |
+| ---------------- | ------------------------------------- | ------------------------------------ |
+| `retro`          | `/retro [plan-path] [--auto]`         | Generate and analyze a retrospective |
+| `ingest-history` | `/ingest-history <path>`              | Extract patterns from histories      |
+| `improve`        | `/improve [--agent <id>] [--dry-run]` | Synthesize learnings into memory     |
+| `agent-metrics`  | `/agent-metrics [--agent <id>]`       | Performance reporting and trends     |
+
+### Human review is not optional
+
+Memory updates are commits. They go through PR review like any other change. An agent
+proposes what it has learned; a human decides whether it is true. `/improve --dry-run`
+exists so that this is the default workflow rather than an afterthought.
+
+## Alternatives Considered
+
+### Alternative 1: Fully automatic memory updates, no human gate
+
+Faster, and the obvious reading of "self-improving." Rejected: a system that writes its
+own instructions from its own output, with no external check, has no mechanism for
+noticing that it has learned something false. The human gate is cheap and is the only
+thing standing between this and confident drift.
+
+### Alternative 2: Fine-tuning instead of memory synthesis
+
+Learned patterns could become training signal rather than context. Rejected as out of
+scope and out of proportion: it requires infrastructure a repository plugin cannot own,
+is not reversible the way a git revert is, and is opaque to review. Memory is auditable
+in a way weights are not.
+
+### Alternative 3: Metrics only, no synthesis
+
+Ship `/agent-metrics` and let humans update memory by hand. Genuinely tempting — it is
+most of the value at a fraction of the risk. Rejected as the _end state_ but accepted as
+the delivery order: metrics and retrospectives are useful alone and should ship before
+`/improve`.
+
+### Alternative 4: Store improvement data outside git
+
+A metrics database would query faster and avoid inflating the repository. Rejected for
+the same reason ADR-017 landed where it did: if it is not in git, it does not survive a
+clone, and it cannot be reviewed or reverted.
+
+## Consequences
+
+### Positive
+
+- Review feedback stops repeating — the single most visible waste in agent work today
+- Conversation histories become an asset rather than an archive
+- `/agent-metrics` gives an objective answer to "are the agents getting better?", which
+  is currently a matter of impression
+- Every learned pattern is a reviewable diff with an author and a revert path
+- Regression detection means a bad update is caught by measurement, not by noticing
+
+### Negative
+
+- The most complex of the three proposals, and the least independently useful
+- Metrics are only as good as the data: sparse runs produce noisy trends that invite
+  over-reading
+- `/ingest-history` must handle unstructured, potentially very large input
+- Adds a per-run cost (retrospective generation) to every orchestration
+
+### Risks
+
+- **Confident drift.** The core risk of any self-modifying system: it learns something
+  wrong, applies it consistently, and the resulting failures look like normal variance.
+  Mitigation: human review of memory diffs, regression detection, and git revert.
+- **Overfitting to recent runs.** A run of unusual failures could produce memory that
+  is wrong in the general case. Mitigation: require a minimum sample before synthesis;
+  prefer patterns seen across multiple runs.
+- **Metric gaming.** If agents optimize for the metrics rather than the outcome —
+  splitting tasks to lower per-task retry rates, for instance — the numbers improve
+  while the work does not. Mitigation: treat metrics as diagnostic, never as an
+  objective handed to the agent.
+- **Privacy.** Conversation histories may contain sensitive content. Mitigation:
+  histories stay local, are never transmitted, and only distilled patterns are written.
+
+## Architecture Impact
+
+- **New:** `docs/architecture/agent-improvement.md` — the capture/analyze/synthesize/
+  inject/verify cycle and its data sources
+- **Update:** `docs/architecture/documentation-pipeline.md` — retrospectives as a
+  pipeline document type with a defined lifecycle
+- **New ADR:** memory updates require human review; the loop is not closed automatically
+- **New ADR:** regression detection thresholds and the revert procedure
+
+## Open Questions
+
+- **What counts as a regression?** A single worse run is noise. How many runs, and how
+  much degradation, before the system flags an update?
+- **How much history is enough?** `/improve` needs a minimum sample to avoid overfitting.
+  What is it, and should it differ by agent role?
+- **Who owns global memory?** Agent-specific memory has a clear owner. `global.md` is
+  edited by every agent — does it need stricter review, or an owner?
+- **Should retrospectives expire?** They accumulate per run indefinitely. Is there a
+  retention policy, or does `/improve` compact them once synthesized?
+- **Delivery order.** Should `/retro` and `/agent-metrics` ship first as read-only
+  capability, with `/improve` gated behind evidence that the metrics are trustworthy?


### PR DESCRIPTION
Documentation only — no code changes. Closes out the four decisions from our review.

## RFC-010 split

RFC-010 covered seven interlocking systems across five phases in ~900 lines. It argued
for staying whole because the systems shared a data plane. **That argument no longer
holds**: principled-tasks shipped the work-unit substrate RFC-010 assumed it would have
to build, which breaks the dependency that bound them together.

| Proposal | Covers | Depends on |
| --- | --- | --- |
| [RFC-011](docs/proposals/011-agent-memory-and-resumability.md) — Agent Memory, Identity, and Resumability | Systems 1, 2, 6 | Nothing new |
| [RFC-012](docs/proposals/012-github-native-agent-collaboration.md) — GitHub-Native Collaboration and Autonomous Execution | Systems 3, 4 | RFC-011; RFC-008 for parallel roles only |
| [RFC-013](docs/proposals/013-agent-self-improvement-loop.md) — Agent Self-Improvement Loop | System 5 | RFC-011, RFC-012 |

System 7 (the `principled-agent` plugin) is distributed — each proposal declares what
it contributes. RFC-010 is marked `superseded` and retained as the strategic vision.

### Two things changed in the split, rather than being carried over

**`.agents/backlog.json` is withdrawn.** principled-tasks already provides a
git-committed work queue with dependency edges, agent assignment, and discovery
provenance. RFC-011 narrows to agent state — properties of the *worker*, not the *work*.
This is a materially smaller Phase 1 than RFC-010 described.

**The memory-format rejection is revisited.** RFC-010 rejected "JSONL + SQLite" as a
memory format. ADR-017 then shipped exactly that pattern for the task graph. RFC-011
addresses the apparent contradiction head-on and concludes both rejections were right
for their own case:

| | Agent memory | Task graph (ADR-017) |
| --- | --- | --- |
| Primary consumer | The LLM, as prose | Scripts, as queries |
| Access pattern | Read whole into context | Filter, aggregate, traverse |
| Write frequency | Occasionally, after a run | Every task transition |
| Merge pressure | Low — one file per agent | High — many agents appending |

Memory is a *document*; the task graph is a *data structure*. The shared principle is
git-native, not one file format.

### On the content

Each RFC follows the canonical proposal template — Audience, Context, Proposal,
Alternatives Considered, Consequences (positive/negative/risks), Architecture Impact,
Open Questions. The material is derived from RFC-010; the alternatives, risks, and open
questions are largely new, because a 900-line umbrella document could not interrogate
each system individually.

Worth a close read in RFC-012 and RFC-013: the governance constraints (agents cannot
approve their own PRs, draft PRs only, no auto-merge under any mode) and the
regression-detection brake on the improvement loop. Those are the parts that make
autonomous execution and self-modification safe to turn on, and they are the parts most
likely to be quietly dropped during implementation.

## ADR acceptance

ADR-017 and ADR-018 move `proposed` → `accepted`. Both are implemented and shipped on
main; leaving them proposed meant the written record disagreed with the code.

ADR-009 (script duplication) is superseded by ADR-018, pointer set in both directions
and status transitioned. Its reasoning is retained as the historical record, with a note
on what the decision cost in practice: 15 copies of one 31-line script, 20% of the
plugin tree redundant, six drift checkers, and a checker that silently missed an
already-diverged copy.

`pipeline-audit.sh` validates the chain and reports it consistent.

## Also

- Clarifies the immutability rule in `CLAUDE.md`: an accepted ADR may record
  supersession — the `superseded_by` field, the status transition, and a Status-section
  pointer — while the reasoning body stays as written. Previously the rule said only
  `superseded_by`, which would have left status and body permanently contradicting the
  frontmatter.
- Corrects the README description of principled-tasks, which still described SQLite
  storage after ADR-017 moved the record to an append-only event log.

## Verification

shellcheck, shfmt, both drift checkers, reference integrity, pipeline audit (0 issues),
structure and manifest validation, hook smoke tests, markdownlint, prettier, 58/58 bats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKzFURKGfB1Ec3ayH2hjE2