### PR TITLE
feat: agent memory and resumability (RFC-011, Plan-010)

### DIFF
--- a/.agents/memory/agents/impl-worker.md
+++ b/.agents/memory/agents/impl-worker.md
@@ -1,0 +1,19 @@
+---
+agent_id: "impl-worker"
+role: worker
+last_updated: 2026-07-28
+session_count: 0
+total_tasks: 0
+success_rate: 0.0
+specializations: []
+---
+
+# impl-worker — Accumulated Knowledge
+
+## Known Patterns
+
+<!-- Durable facts about this codebase that this agent should not relearn. -->
+
+## Pitfalls
+
+<!-- Mistakes made before, and what to do instead. -->

--- a/.agents/memory/agents/issue-ingester.md
+++ b/.agents/memory/agents/issue-ingester.md
@@ -1,0 +1,19 @@
+---
+agent_id: "issue-ingester"
+role: worker
+last_updated: 2026-07-28
+session_count: 0
+total_tasks: 0
+success_rate: 0.0
+specializations: []
+---
+
+# issue-ingester — Accumulated Knowledge
+
+## Known Patterns
+
+<!-- Durable facts about this codebase that this agent should not relearn. -->
+
+## Pitfalls
+
+<!-- Mistakes made before, and what to do instead. -->

--- a/.agents/memory/agents/pr-reviewer.md
+++ b/.agents/memory/agents/pr-reviewer.md
@@ -1,0 +1,19 @@
+---
+agent_id: "pr-reviewer"
+role: worker
+last_updated: 2026-07-28
+session_count: 0
+total_tasks: 0
+success_rate: 0.0
+specializations: []
+---
+
+# pr-reviewer — Accumulated Knowledge
+
+## Known Patterns
+
+<!-- Durable facts about this codebase that this agent should not relearn. -->
+
+## Pitfalls
+
+<!-- Mistakes made before, and what to do instead. -->

--- a/.agents/memory/global.md
+++ b/.agents/memory/global.md
@@ -1,0 +1,44 @@
+---
+scope: global
+last_updated: 2026-07-28
+---
+
+# Global Agent Memory
+
+Knowledge that applies to every agent in this repository. Keep this curated: every
+byte here is injected into every agent's context.
+
+## Conventions
+
+- Shared code lives in each plugin's `lib/`, referenced as
+  `${CLAUDE_PLUGIN_ROOT}/lib/<name>` (ADR-018). Never copy a `lib/` script into a skill
+  directory, and never reference a sibling plugin's `lib/` — plugins install
+  independently, so `${CLAUDE_PLUGIN_ROOT}` cannot reach across the boundary.
+- `scripts/check-skill-references.sh` fails on a bare relative path as well as a missing
+  one. A path only resolves at runtime if it goes through `${CLAUDE_PLUGIN_ROOT}`.
+
+## Shell constraints
+
+- Stock macOS ships bash 3.2. No `declare -A`, no `local -n`, no `mapfile`, no
+  `${var,,}`, no `grep -P`.
+- **Never use `sed -i`.** BSD sed reads the next argument as a backup suffix, so
+  `sed -i <expr> <file>` misparses on macOS while working on Linux. Use `awk` into a
+  temp file and `mv`. This silently broke the no-jq path of `task-manifest.sh` for
+  every status update and every task after the first.
+- `jq` is optional everywhere. Every script needs a working fallback, and the fallback
+  must be tested with a PATH that genuinely lacks `jq` — trimming PATH to `/usr/bin:/bin`
+  does not work, because `jq` lives in `/usr/bin` on macOS.
+- Prefer bash built-ins over subprocesses for validation: `[[ "$v" =~ ^[0-9]+$ ]]` beats
+  piping to `grep`, and removes a dependency from the fallback path.
+
+## Hooks
+
+- Guard scripts default to allow. Exit 0 = allow, exit 2 = block. Never exit 1 — that is
+  reserved for script errors.
+- Advisory hooks always exit 0. A hook on `SubagentStart` that exits non-zero blocks
+  agent spawning entirely.
+
+## Pipeline
+
+- Accepted ADRs and terminal-status proposals are immutable and hook-enforced. Make every
+  edit to a document _before_ moving it to a terminal status, in the same pass.

--- a/.agents/registry.json
+++ b/.agents/registry.json
@@ -1,0 +1,47 @@
+{
+  "version": 1,
+  "agents": [
+    {
+      "id": "impl-worker",
+      "plugin": "principled-implementation",
+      "role": "worker",
+      "memory": true,
+      "rationale": "Primary beneficiary — implementation patterns and codebase knowledge"
+    },
+    {
+      "id": "issue-ingester",
+      "plugin": "principled-github",
+      "role": "triage",
+      "memory": true,
+      "rationale": "Triage and classification patterns accumulate"
+    },
+    {
+      "id": "pr-reviewer",
+      "plugin": "principled-quality",
+      "role": "reviewer",
+      "memory": true,
+      "rationale": "Learns recurring review themes"
+    },
+    {
+      "id": "module-auditor",
+      "plugin": "principled-docs",
+      "role": "auditor",
+      "memory": false,
+      "rationale": "Runs a deterministic script; nothing to learn"
+    },
+    {
+      "id": "decision-auditor",
+      "plugin": "principled-docs",
+      "role": "auditor",
+      "memory": false,
+      "rationale": "Checks supersession chains deterministically"
+    },
+    {
+      "id": "boundary-checker",
+      "plugin": "principled-architecture",
+      "role": "auditor",
+      "memory": false,
+      "rationale": "Scans imports against fixed rules"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -100,6 +100,21 @@
       ]
     },
     {
+      "name": "principled-agent",
+      "source": "./plugins/principled-agent",
+      "description": "Persistent agent identity and memory. Git-committed, reviewable knowledge that agents accumulate across sessions, injected at spawn and revised in pull requests.",
+      "version": "0.1.0",
+      "category": "orchestration",
+      "keywords": [
+        "agent",
+        "memory",
+        "identity",
+        "resumability",
+        "orchestration",
+        "retrospective"
+      ]
+    },
+    {
       "name": "principled-tasks",
       "source": "./plugins/principled-tasks",
       "description": "Git-native, graph-structured task tracking backed by an append-only event log. Tracks tasks with typed dependency edges across plans and agents, and merges cleanly across parallel agent branches.",

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,7 +4,7 @@ This file supplements the root `CLAUDE.md` with development-specific guidance fo
 
 ## Dogfooding
 
-All seven first-party plugins are installed via `.claude/settings.json`. See root `CLAUDE.md` § Dogfooding for the full list of available skills and active hooks.
+All eight first-party plugins are installed via `.claude/settings.json`. See root `CLAUDE.md` § Dogfooding for the full list of available skills and active hooks.
 
 ## Common Pitfalls
 
@@ -27,13 +27,14 @@ All seven first-party plugins are installed via `.claude/settings.json`. See roo
 - Run `bash plugins/principled-docs/skills/scaffold/scripts/check-template-drift.sh` to verify zero drift.
 - Forgetting to propagate = CI failure.
 
-### Modifying Shared Code (principled-implementation, principled-tasks)
+### Modifying Shared Code (`lib/`)
 
-These plugins use the `lib/` pattern (ADR-018) — one copy, no propagation:
+Every plugin now uses the `lib/` pattern (ADR-018) — one copy, no propagation:
 
 - `plugins/principled-implementation/lib/{task-manifest,parse-plan,run-checks}.sh`
 - `plugins/principled-implementation/lib/templates/claude-task.md`
 - `plugins/principled-tasks/lib/task-db.sh`
+- `plugins/principled-agent/lib/agent-memory.sh`
 
 Edit in place. Skills reference them as `${CLAUDE_PLUGIN_ROOT}/lib/<name>`.
 
@@ -81,6 +82,29 @@ ADR-018.
 - Advisory only --- always exits 0. Never blocks.
 - Triggers on Write of source files (`.ts`, `.tsx`, `.js`, `.jsx`, `.py`, `.go`, `.rs`, `.java`).
 - Checks for module dependency direction violations by scanning imports against the module type system (ADR-003, ADR-014).
+
+### Editing Hook Scripts (principled-agent)
+
+- Injection reads an agent id from stdin JSON, trying `agent_id`, `subagent_type`,
+  `agent_type`, then `agent` — the field name has varied across Claude Code versions:
+  `echo '{"agent_id":"impl-worker"}' | bash plugins/principled-agent/hooks/scripts/inject-agent-memory.sh`
+- Integrity uses `tool_input.file_path` and only reacts to paths under `.agents/`.
+- Both always exit 0. Injection runs on `SubagentStart`, so a non-zero exit would block
+  agent spawning outright.
+- **Never make injection truncate.** An agent handed a silently halved memory file has a
+  confidently incomplete picture and no way to notice. Oversized memory is reported by
+  the integrity hook; it is never trimmed on the way in.
+
+### Editing the Manifest Schema (principled-implementation)
+
+- `checkpoint` and `acceptance_criteria` are additive and optional (ADR-021). Every
+  consumer must tolerate their absence and ignore unknown fields.
+- **Do not use `sed -i`.** BSD sed reads the next argument as a backup suffix, so
+  `sed -i <expr> <file>` misparses on stock macOS. The no-jq fallback was broken this way
+  for the second task onward and for every status update. Use `awk` into a temp file and
+  `mv`, which behaves identically on both platforms.
+- Test both paths. `tests/manifest-checkpoint.bats` runs each operation with jq and with
+  a PATH that genuinely lacks it, then validates the result with the real jq.
 
 ### Changing Frontmatter Schema
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,6 +29,7 @@
     "principled-quality@principled-marketplace": true,
     "principled-release@principled-marketplace": true,
     "principled-architecture@principled-marketplace": true,
-    "principled-tasks@principled-marketplace": true
+    "principled-tasks@principled-marketplace": true,
+    "principled-agent@principled-marketplace": true
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ core
 
 ## What This Is
 
-This repo is the **Principled methodology plugin marketplace** (v0.4.0, pre-1.0). It hosts Claude Code plugins for specification-first development, organized as a curated directory with two tiers: first-party plugins in `plugins/` and community plugins in `external_plugins/`. Seven first-party plugins ship today:
+This repo is the **Principled methodology plugin marketplace** (v0.4.0, pre-1.0). It hosts Claude Code plugins for specification-first development, organized as a curated directory with two tiers: first-party plugins in `plugins/` and community plugins in `external_plugins/`. Eight first-party plugins ship today:
 
 - **principled-docs** (v0.3.1) — Scaffold, author, and enforce module documentation structure for monorepos.
 - **principled-implementation** (v0.1.0) — Orchestrate DDD plan execution via worktree-isolated Claude Code agents.
@@ -15,22 +15,24 @@ This repo is the **Principled methodology plugin marketplace** (v0.4.0, pre-1.0)
 - **principled-release** (v0.1.0) — Generate changelogs from the documentation pipeline, verify release readiness, coordinate version bumps, and govern the release lifecycle.
 - **principled-architecture** (v0.1.0) — Map code to architectural decisions, detect drift, audit decision coverage, and keep architecture documents synchronized.
 - **principled-tasks** (v0.1.0) — Git-native, graph-linked task tracking backed by an append-only event log — open, close, update, query, audit, and visualize tasks across agent workflows.
+- **principled-agent** (v0.1.0) — Persistent agent identity and memory: git-committed knowledge injected at spawn and revised in pull requests.
 
 ## Architecture
 
-Ten layers, top to bottom:
+Eleven layers, top to bottom:
 
 | Layer                   | Location                                                           | Role                                                                                                                 |
 | ----------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
 | **Marketplace**         | `.claude-plugin/marketplace.json`, `plugins/`, `external_plugins/` | Plugin catalog, directory structure, plugin discovery and distribution                                               |
 | **Docs: Skills**        | `plugins/principled-docs/skills/` (9 directories)                  | Generative workflows — each skill is a slash command with its own `SKILL.md`, templates, scripts, and reference docs |
 | **Docs: Hooks**         | `plugins/principled-docs/hooks/`                                   | Deterministic guardrails — `hooks.json` declares PreToolUse/PostToolUse triggers that run shell scripts              |
-| **Implementation: All** | `plugins/principled-implementation/`                               | Skills (6), hooks (5), agents (1) for plan execution via worktree-isolated sub-agents and agent teams                |
+| **Implementation: All** | `plugins/principled-implementation/`                               | Skills (7), hooks (5), agents (1) for plan execution via worktree-isolated sub-agents and agent teams                |
 | **GitHub: All**         | `plugins/principled-github/`                                       | Skills (9), hooks (1), agents (1) for GitHub integration: issues, PRs, templates, CODEOWNERS, labels                 |
 | **Quality: All**        | `plugins/principled-quality/`                                      | Skills (5), hooks (1), agents (1) for spec-driven code review: checklists, context, coverage, summaries              |
 | **Release: All**        | `plugins/principled-release/`                                      | Skills (6), hooks (1) for release lifecycle: changelogs, readiness, version bumps, tagging                           |
 | **Architecture: All**   | `plugins/principled-architecture/`                                 | Skills (6), hooks (1), agents (1) for architecture governance: mapping, drift detection, auditing, sync              |
 | **Tasks: All**          | `plugins/principled-tasks/`                                        | Skills (7), 1 hook, and `lib/task-db.sh` for the event-log task graph: open, close, update, query, audit, visualize  |
+| **Agent: All**          | `plugins/principled-agent/`                                        | Skills (4), 2 hooks, and `lib/agent-memory.sh` for `.agents/` identity, memory injection, and integrity              |
 | **Dev DX**              | `.claude/`, config files, `.github/workflows/`                     | Project-level Claude Code settings, dev skills, CI pipeline, linting config                                          |
 
 ## Skills
@@ -49,16 +51,17 @@ Ten layers, top to bottom:
 | `new-architecture-doc` | `/new-architecture-doc <title>`          | Generative |
 | `proposal-status`      | `/proposal-status NNN <status>`          | Analytical |
 
-### principled-implementation (6 skills)
+### principled-implementation (7 skills)
 
-| Skill           | Command                                             | Category      |
-| --------------- | --------------------------------------------------- | ------------- |
-| `impl-strategy` | _(background — not user-invocable)_                 | Knowledge     |
-| `decompose`     | `/decompose <plan-path>`                            | Analytical    |
-| `spawn`         | `/spawn <task-id>`                                  | Orchestration |
-| `check-impl`    | `/check-impl [--task <id>] [--all]`                 | Analytical    |
-| `merge-work`    | `/merge-work <task-id> [--force] [--no-cleanup]`    | Orchestration |
-| `orchestrate`   | `/orchestrate <plan-path> [--phase N] [--continue]` | Orchestration |
+| Skill           | Command                                                | Category      |
+| --------------- | ------------------------------------------------------ | ------------- |
+| `impl-strategy` | _(background — not user-invocable)_                    | Knowledge     |
+| `decompose`     | `/decompose <plan-path>`                               | Analytical    |
+| `spawn`         | `/spawn <task-id>`                                     | Orchestration |
+| `check-impl`    | `/check-impl [--task <id>] [--all]`                    | Analytical    |
+| `merge-work`    | `/merge-work <task-id> [--force] [--no-cleanup]`       | Orchestration |
+| `orchestrate`   | `/orchestrate <plan-path> [--phase N] [--continue]`    | Orchestration |
+| `resume`        | `/resume [<plan-path>] [--from-checkpoint] [--replan]` | Orchestration |
 
 ### principled-github (9 skills)
 
@@ -118,11 +121,21 @@ Ten layers, top to bottom:
 | `task-audit`    | `/task-audit [--all]`                                       | Analytical |
 | `task-graph`    | `/task-graph [--format dot\|text] [--status <status>]`      | Analytical |
 
+### principled-agent (4 skills)
+
+| Skill            | Command                                             | Category   |
+| ---------------- | --------------------------------------------------- | ---------- |
+| `agent-strategy` | _(background — not user-invocable)_                 | Knowledge  |
+| `agent-init`     | `/agent-init [--commit]`                            | Generative |
+| `agent-memory`   | `/agent-memory [<id>] [--list] [--learn] [--check]` | Analytical |
+| `agent-retro`    | `/agent-retro [<plan-path>] [--promote]`            | Generative |
+
 Skills own their own prompts and templates. Code shared by more than one skill in a
 plugin lives in that plugin's `lib/` and is referenced as `${CLAUDE_PLUGIN_ROOT}/lib/...`
-— one copy, no drift checker (ADR-018). principled-tasks follows this pattern today;
-the other plugins still use the older copy-with-drift-detection scheme (ADR-009) and
-are being migrated.
+— one copy, no drift checker (ADR-018). The migration off ADR-009's
+copy-with-drift-detection scheme is complete: no script under `skills/*/scripts/` is
+referenced by more than one SKILL.md in its plugin. Scripts that remain in a skill
+directory are used by that skill alone, which is where they belong.
 
 ## Agents
 
@@ -156,6 +169,7 @@ drift checker — drift is impossible rather than detected.
 | principled-release        | `check-gh-cli.sh` (vendored), `collect-changes.sh`, `check-readiness.sh`, `detect-modules.sh` |
 | principled-architecture   | `scan-modules.sh`                                                                             |
 | principled-tasks          | `task-db.sh`                                                                                  |
+| principled-agent          | `agent-memory.sh`                                                                             |
 
 `scripts/check-skill-references.sh` verifies every referenced path resolves **and**
 that it uses `${CLAUDE_PLUGIN_ROOT}`. Both halves matter. The old drift checkers
@@ -226,8 +240,11 @@ This repo uses its own documentation pipeline at the root level (governing the m
   - 017: Event log as record, SQLite as cache (principled-tasks storage)
   - 018: Shared plugin `lib/` over copy-with-drift-detection (supersedes 009)
   - 019: Bats for shell testing
+  - 020: Agent memory as a frontmatter document (not an event log)
+  - 021: Manifest checkpoint and criterion-level acceptance tracking
 - `docs/architecture/` — Living design docs.
-  - plugin-system.md, documentation-pipeline.md, enforcement-system.md
+  - plugin-system.md, documentation-pipeline.md, enforcement-system.md,
+    architecture-governance.md, release-system.md, agent-memory.md
 
 ## Versioning
 
@@ -258,15 +275,16 @@ See `CONTRIBUTING.md` for the full contributor guide. Key points:
 
 ## Dogfooding
 
-This repo installs all seven first-party plugins (via `.claude/settings.json`):
+This repo installs all eight first-party plugins (via `.claude/settings.json`):
 
 - **principled-docs** — All 9 skills, 8 enforcement hooks, and 2 agents are active during development.
-- **principled-implementation** — All 6 skills, the `impl-worker` agent, and 5 hooks (1 advisory + 4 lifecycle) are active during development. Agent teams available when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`.
+- **principled-implementation** — All 7 skills, the `impl-worker` agent, and 5 hooks (1 advisory + 4 lifecycle) are active during development. Agent teams available when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`.
 - **principled-github** — All 9 skills, 1 advisory hook, and the `issue-ingester` agent are active during development.
 - **principled-quality** — All 5 skills, 1 advisory hook, and the `pr-reviewer` agent are active during development.
 - **principled-release** — All 6 skills and 1 advisory hook are active during development.
 - **principled-architecture** — All 6 skills, 1 advisory hook, and the `boundary-checker` agent are active during development.
 - **principled-tasks** — All 7 skills and 1 advisory hook are active during development. Shared code lives in `lib/task-db.sh` (ADR-018).
+- **principled-agent** — All 4 skills and 2 hooks (memory injection + integrity advisory) are active during development. Shared code lives in `lib/agent-memory.sh` (ADR-018).
 
 See `.claude/CLAUDE.md` for development-specific context.
 
@@ -380,13 +398,28 @@ Declared in `plugins/principled-tasks/hooks/hooks.json`:
 Advisory only — warns on direct edits to `.principled/tasks.jsonl` (the record) or
 `.impl/tasks.db` (the derived cache). Always exits 0.
 
+### principled-agent
+
+Declared in `plugins/principled-agent/hooks/hooks.json`:
+
+| Hook                      | Event                     | Script                                                             | Timeout |
+| ------------------------- | ------------------------- | ------------------------------------------------------------------ | ------- |
+| Agent Memory Injection    | SubagentStart             | `plugins/principled-agent/hooks/scripts/inject-agent-memory.sh`    | 10s     |
+| Memory Integrity Advisory | PostToolUse (Edit\|Write) | `plugins/principled-agent/hooks/scripts/check-memory-integrity.sh` | 10s     |
+
+- Agent Memory Injection: emits global and per-agent memory to stderr at spawn. Only
+  agents the registry marks `memory: true` receive anything. Never truncates, always
+  exits 0 — a memory problem must not stop an agent running.
+- Memory Integrity Advisory: validates frontmatter and reports against the 8 KB / 16 KB
+  context budget on writes under `.agents/`. Always exits 0.
+
 ## Testing
 
 - **Template drift (docs):** `plugins/principled-docs/skills/scaffold/scripts/check-template-drift.sh` — exits non-zero if any copy diverges from canonical.
 - **Cross-plugin drift:** `scripts/check-cross-plugin-drift.sh` — exits non-zero if a vendored `check-gh-cli.sh` diverges from canonical.
 - **Pipeline audit:** `scripts/pipeline-audit.sh` — reconciles declared document state against the repository (numbering, plan/proposal links, statuses, supersession chains).
 - **Reference integrity:** `scripts/check-skill-references.sh` — exits non-zero if any script or template referenced by a SKILL.md or hooks.json does not exist.
-- **Tests:** `npx bats tests/` — bats suite covering the task graph library. Also run on macOS bash 3.2 in CI.
+- **Tests:** `npx bats tests/` — bats suite covering the task graph library, agent memory, the manifest checkpoint and criteria, and every hook. Also run on macOS bash 3.2 in CI.
 - **Structure validation:** `plugins/principled-docs/lib/validate-structure.sh --module-path <path> [--type <type>] [--strict] [--json]` — checks a module's docs structure.
 - **Root validation:** `plugins/principled-docs/lib/validate-structure.sh --root` — checks repo-level docs structure.
 - **Hook testing (docs):** Feed JSON with `tool_input.file_path` to guard scripts via stdin. Exit 0 = allow, exit 2 = block.
@@ -396,7 +429,8 @@ Advisory only — warns on direct edits to `.principled/tasks.jsonl` (the record
 - **Hook testing (release):** Feed JSON with `tool_input.command` to `check-release-readiness.sh` via stdin. Always exits 0 (advisory).
 - **Hook testing (architecture):** Feed JSON with `tool_input.file_path` to `check-boundary-violation.sh` via stdin. Always exits 0 (advisory).
 - **Hook testing (tasks):** Feed JSON with `tool_input.file_path` to `check-db-integrity.sh` via stdin. Always exits 0 (advisory).
-- **Hook testing (all):** `npx bats tests/hooks.bats` — 30 tests covering allow, block, malformed input, and the no-jq fallback path for every hook.
+- **Hook testing (agent):** Feed JSON with an agent id to `inject-agent-memory.sh`, or `tool_input.file_path` to `check-memory-integrity.sh`, via stdin. Both always exit 0.
+- **Hook testing (all):** `npx bats tests/hooks.bats` — 48 tests covering allow, block, malformed input, and the no-jq fallback path for every hook.
 - **Shell lint:** `shellcheck --shell=bash` and `shfmt -i 2 -bn -sr -d` on all `.sh` files.
 - **Markdown lint:** `npx markdownlint-cli2 '**/*.md'` and `npx prettier --check '**/*.md'`.
 - **Marketplace validation:** Verify `.claude-plugin/marketplace.json` is valid and all plugin source directories exist.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A Claude Code plugin marketplace hosting first-party and community plugins for t
 | [**principled-release**](plugins/principled-release/README.md)               | workflow       | Generate changelogs from the documentation pipeline, verify release readiness, and coordinate versioned releases (v0.1.0)          |
 | [**principled-architecture**](plugins/principled-architecture/README.md)     | architecture   | Map modules to governing ADRs, detect architectural drift, audit governance coverage, and sync architecture docs (v0.1.0)          |
 | [**principled-tasks**](plugins/principled-tasks/README.md)                   | workflow       | Git-native, graph-linked task tracking backed by an append-only event log — merges cleanly across parallel agent branches (v0.1.0) |
+| [**principled-agent**](plugins/principled-agent/README.md)                   | orchestration  | Persistent agent identity and memory — git-committed knowledge injected at spawn and revised in pull requests (v0.1.0)             |
 
 ### Community
 
@@ -52,6 +53,7 @@ _No community plugins yet. See [Contributing](#-contributing-a-plugin) to submit
 /plugin install principled-release@principled-marketplace
 /plugin install principled-architecture@principled-marketplace
 /plugin install principled-tasks@principled-marketplace
+/plugin install principled-agent@principled-marketplace
 ```
 
 ### Team-Wide Adoption
@@ -75,7 +77,8 @@ Add to your project's `.claude/settings.json`:
     "principled-quality@principled-marketplace": true,
     "principled-release@principled-marketplace": true,
     "principled-architecture@principled-marketplace": true,
-    "principled-tasks@principled-marketplace": true
+    "principled-tasks@principled-marketplace": true,
+    "principled-agent@principled-marketplace": true
   }
 }
 ```
@@ -92,7 +95,8 @@ principled/
 │   ├── principled-github/       # GitHub integration plugin
 │   ├── principled-quality/      # Code review quality plugin
 │   ├── principled-release/     # Release lifecycle plugin
-│   └── principled-architecture/ # Architecture governance plugin
+│   ├── principled-architecture/ # Architecture governance plugin
+│   └── principled-agent/       # Agent identity and memory plugin
 ├── external_plugins/            # Community plugins
 ├── docs/                        # Marketplace governance
 │   ├── proposals/               # RFCs

--- a/docs/architecture/agent-memory.md
+++ b/docs/architecture/agent-memory.md
@@ -1,0 +1,173 @@
+---
+title: "Agent Memory and Resumability"
+last_updated: 2026-07-28
+related_adrs: [020, 021, 008, 017]
+---
+
+# Agent Memory and Resumability
+
+## Purpose
+
+Describes the `.agents/` contract, how memory reaches an agent, and how an interrupted
+orchestration run resumes with its reasoning intact. Intended for contributors extending
+agent state, and for anyone deciding which of the three state stores a new field belongs
+to.
+
+## The three state stores
+
+The repository now keeps three kinds of durable state, and the most common design
+mistake is putting a field in the wrong one.
+
+| Store               | Location                  | Owns                        | Governed by |
+| ------------------- | ------------------------- | --------------------------- | ----------- |
+| Agent memory        | `.agents/`                | What the worker has learned | ADR-020     |
+| Orchestration state | `.impl/manifest.json`     | What execution has happened | ADR-008/021 |
+| Work backlog        | `.principled/tasks.jsonl` | What needs doing            | ADR-017     |
+
+The deciding question: **would this still be true after every open task closed?** If
+yes, it is memory. If it describes a run, it is orchestration state. If it describes work
+outstanding, it is the backlog.
+
+A second test separates the first two: memory is a property of the _worker_, the
+checkpoint is a property of the _work_. That is why they live in different plugins —
+`impl-worker`, `issue-ingester`, and `pr-reviewer` belong to three different plugins that
+install independently and cannot reference each other's `${CLAUDE_PLUGIN_ROOT}`.
+
+## Layout
+
+```
+.agents/
+  registry.json                    # who exists, who carries memory, and why
+  memory/
+    global.md                      # applies to every memory-bearing agent
+    agents/
+      impl-worker.md               # one file per memory-bearing agent
+      issue-ingester.md
+      pr-reviewer.md
+  retrospectives/
+    2026-07-28-plan-008.md         # dated record of one run
+```
+
+`.agents/` is **committed**, unlike the gitignored `.claude/agent-memory/`. That is the
+load-bearing property: memory arrives through pull requests, so a bad learned pattern is
+visible before it merges and revertable afterwards.
+
+## Memory format
+
+Markdown with YAML frontmatter (ADR-020). Frontmatter is script-owned metadata;
+the body is prose the model consumes directly.
+
+Memory is **revised, not appended**. This is the deliberate difference from the task
+graph's event log (ADR-017), where past entries are immutable: a wrong learned pattern
+that cannot be deleted compounds on every spawn.
+
+The full comparison, and why the same storage decision does not apply to both:
+
+|                  | Agent memory                 | Task graph (ADR-017)              |
+| ---------------- | ---------------------------- | --------------------------------- |
+| Primary consumer | The LLM, as prose            | Scripts, as queries               |
+| Access pattern   | Read whole file into context | Filter, aggregate, traverse edges |
+| Write frequency  | Occasionally, after a run    | Every task transition             |
+| Merge pressure   | Low — one file per agent     | High — many agents appending      |
+
+## Injection
+
+```
+SubagentStart
+  └─ inject-agent-memory.sh
+       ├─ extract agent id from the event payload
+       ├─ no .agents/ directory?        → exit 0, silent
+       ├─ no memory file for this agent → exit 0, silent
+       └─ emit global.md body + <agent>.md body to stderr
+```
+
+Three properties matter:
+
+**It never blocks.** The hook runs on every subagent spawn, so a failure would stop
+agents running at all. Every path exits 0, including malformed input and an
+uninitialized repository.
+
+**It never truncates.** An agent handed a silently halved memory file has a confidently
+incomplete picture, and the loss is invisible to it. Oversized memory is reported by
+`check-memory-integrity.sh`, never quietly trimmed.
+
+**Only memory-bearing agents receive anything**, including global memory. `module-auditor`,
+`decision-auditor`, and `boundary-checker` run deterministic scripts and learn nothing by
+definition, so injecting conventions into them spends context for no benefit.
+
+## The context budget
+
+Memory competes with the task description for the model's attention, so the budget is
+stated in bytes rather than in records:
+
+| Size         | Behaviour                                       |
+| ------------ | ----------------------------------------------- |
+| under 8 KB   | silent                                          |
+| 8 KB – 16 KB | advisory warning, synthesis suggested           |
+| over 16 KB   | louder warning; injection still delivers it all |
+
+The budget is advisory because the cure — synthesis, rewriting many notes into fewer
+denser statements — requires judgment the hook does not have. Until RFC-013's `/improve`
+lands, that is a human act, which is exactly the reviewability the design argues for.
+
+## Resumability
+
+```
+session dies mid-plan
+  └─ .impl/manifest.json survives   (task state + checkpoint)
+  └─ worktrees survive              (ADR-007)
+
+/resume
+  ├─ read checkpoint       → previous session's reasoning
+  ├─ reconcile vs task state → report divergence, never auto-fix
+  ├─ correlate vs task graph → report divergence, skip if absent
+  ├─ read acceptance criteria → resume at first unverified
+  └─ hand off to /orchestrate --continue or /spawn
+```
+
+### Why the checkpoint is advisory
+
+The manifest records that task 2b is `failed` with `retries: 2`. It cannot record that
+retrying is the wrong move. The checkpoint's `orchestrator_summary` carries that
+reasoning.
+
+But a checkpoint is written by a session that may have been failing when it wrote it, so
+it can describe a state that never held. **Task state is authoritative; the checkpoint is
+context** (ADR-021). Where they disagree, task state wins and the divergence is reported
+rather than silently reconciled — a disagreement is usually evidence that a session died
+between two writes, and that evidence is worth more than tidy agreement.
+
+The same rule governs correlation with the task graph: `/resume` reports mismatches and
+writes to neither store.
+
+### Why criteria are not a hierarchy level
+
+Sub-task resumability could have come from a fourth level, Plan → Phase → Task → Step.
+That would break ADR-008's decomposition contract, change `/decompose`'s output shape,
+and change the `impl-worker` contract.
+
+Instead, acceptance criteria — which tasks already carried as prose — became individually
+addressable as a **property of a task**. Tasks remain the unit of decomposition,
+spawning, validation, and merge. `/check-impl` is still the acceptance gate; a ticked
+criterion is a resumption hint and an agent's claim, not a proof.
+
+## Retrospectives versus memory
+
+A retrospective is a dated record of one run. Memory is undated knowledge asserted as
+currently true. Most of a retrospective must never reach memory:
+
+- "task-2b failed twice on the test suite" — a fact about one run. Retrospective.
+- "this suite needs `--runInBand` or the fixtures collide" — a fact about the codebase.
+  Memory.
+
+Keeping them separate is what stops memory degrading into a log, which is the failure
+mode the byte budget exists to detect.
+
+## Related
+
+- [ADR-020: Agent Memory as a Frontmatter Document](../decisions/020-agent-memory-as-document.md)
+- [ADR-021: Manifest Checkpoint and Criterion-Level Acceptance](../decisions/021-manifest-checkpoint-schema.md)
+- [ADR-008: Manifest-Driven Orchestration State](../decisions/008-manifest-driven-orchestration-state.md)
+- [ADR-017: Event Log as Record, SQLite as Cache](../decisions/017-event-log-task-graph.md)
+- [RFC-011: Agent Memory, Identity, and Resumability](../proposals/011-agent-memory-and-resumability.md)
+- [Plan-010](../plans/010-agent-memory-and-resumability.md)

--- a/docs/decisions/020-agent-memory-as-document.md
+++ b/docs/decisions/020-agent-memory-as-document.md
@@ -1,0 +1,164 @@
+---
+title: "Agent Memory as a Frontmatter Document, Not an Event Log"
+number: "020"
+status: accepted
+author: Alex
+created: 2026-07-28
+updated: 2026-07-28
+originating_proposal: "011"
+supersedes: null
+superseded_by: null
+---
+
+# ADR-020: Agent Memory as a Frontmatter Document, Not an Event Log
+
+## Status
+
+Accepted
+
+<!-- Valid values: proposed, accepted, deprecated, superseded -->
+<!-- Once accepted, this document is IMMUTABLE. -->
+<!-- Exception: superseded_by may be updated when a new ADR supersedes this one. -->
+
+## Context
+
+RFC-011 introduces persistent agent memory: a git-committed record of what an agent has
+learned about a codebase, injected into its context when it spawns. A storage format has
+to be chosen, and the repository has already made an adjacent choice that pulls in a
+different direction.
+
+ADR-017 stores the task graph as an append-only JSONL event log with a derived SQLite
+cache. That decision is recent, accepted, and shipped in principled-tasks. The obvious
+move is to reuse it — one storage pattern for all git-native agent state, one set of
+merge semantics, one body of code.
+
+RFC-010 rejected an event log for memory without argument. That rejection could not
+stand once ADR-017 shipped the pattern successfully, so the question was reopened.
+
+### What memory is actually for
+
+Memory has exactly one consumer at read time: the language model, reading prose into its
+context window at spawn. Nothing filters it, aggregates it, or traverses it. The whole
+file is read, or none of it is.
+
+That is the opposite of the task graph's access pattern, and the difference is not
+incidental:
+
+|                  | Agent memory                 | Task graph (ADR-017)              |
+| ---------------- | ---------------------------- | --------------------------------- |
+| Primary consumer | The LLM, as prose            | Scripts, as queries               |
+| Access pattern   | Read whole file into context | Filter, aggregate, traverse edges |
+| Write frequency  | Occasionally, after a run    | Every task transition             |
+| Merge pressure   | Low — one file per agent     | High — many agents appending      |
+| Unit of value    | A curated paragraph          | A single immutable fact           |
+
+An event log is the right answer when many writers append small immutable facts
+concurrently and readers reconstruct state by folding them. Memory has none of those
+properties. One agent owns its file, writes to it rarely, and every write is a revision
+of prose rather than an appended fact.
+
+## Decision
+
+**Agent memory files are markdown documents with YAML frontmatter, one file per agent,
+committed to git and edited in place.**
+
+```markdown
+---
+agent_id: "impl-worker"
+role: worker
+last_updated: 2026-07-28
+session_count: 12
+total_tasks: 47
+success_rate: 0.91
+specializations: ["bash", "hook-authoring"]
+---
+
+# impl-worker — Accumulated Knowledge
+
+## Known Patterns
+
+- Shared scripts live in each plugin's `lib/`, referenced via `${CLAUDE_PLUGIN_ROOT}`
+  (ADR-018). Never copy one into a skill directory.
+- macOS ships bash 3.2. No `declare -A`, no `local -n`, no `grep -P`.
+```
+
+Frontmatter carries queryable metadata — the fields a script needs for routing, metrics,
+and integrity checks. The body carries knowledge, in the form the model consumes
+directly. This is the same shape as every other pipeline document, so the existing
+frontmatter tooling applies unchanged.
+
+The corollary: **memory is revised, not appended.** A learning that turns out to be wrong
+is edited out, and git history records that it was ever believed. The event log's
+defining property — immutability of past entries — is the property memory specifically
+must not have, because a wrong learned pattern that cannot be deleted is a defect that
+compounds on every spawn.
+
+Metrics in frontmatter are maintained by `agent-memory.sh`, not hand-edited, and are the
+only part of the file a script rewrites.
+
+## Options Considered
+
+### Option 1: Markdown with YAML frontmatter (chosen)
+
+Readable by the model without transformation, queryable by scripts through the existing
+`parse-frontmatter.sh`, reviewable in a PR diff like any document, and revisable.
+
+Costs: no concurrent-write story beyond git's own merge, and no structural guarantee
+that the body stays curated. Both are acceptable — writes are rare and single-owner, and
+curation is enforced advisorily by a size budget (RFC-011).
+
+### Option 2: Pure markdown, no frontmatter
+
+Maximally natural for the model, but metrics and specializations become unqueryable, so
+routing and integrity checking would have to parse prose. It would also be the only
+pipeline document without frontmatter, making it second-class to the lifecycle tooling.
+Rejected.
+
+### Option 3: Pure JSON or YAML
+
+Fully structured and trivially queryable, but the primary consumer is a language model,
+and prose in a nested data structure reads worse than prose in a document. It optimises
+for the secondary consumer at the expense of the primary one. Rejected.
+
+### Option 4: Event log plus SQLite cache, mirroring ADR-017
+
+Consistent with the adjacent decision and genuinely better under concurrent writes. It
+was rejected because memory does not have concurrent writes to protect, and the cost is
+severe in the one dimension that matters: the model's input becomes a fold over an event
+stream rather than a document, and correcting a bad learning becomes a compensating
+entry rather than a deletion.
+
+Rejecting it here does not weaken ADR-017. The two decisions differ because the
+workloads differ, and the shared principle — state lives in git, in plain text, visible
+in review — is honoured by both.
+
+## Consequences
+
+### Positive
+
+- The model's primary input is a document, in the form it consumes best
+- Memory diffs are readable in PR review, so a bad learned pattern is visible before it
+  is merged and revertable after
+- Wrong learnings are deleted outright rather than compensated for
+- Reuses `parse-frontmatter.sh` and the pipeline's existing document conventions; no new
+  storage engine, no cache to invalidate, no merge driver to register
+- No SQLite dependency for memory
+
+### Negative
+
+- Concurrent writes to one agent's memory file from parallel sessions can conflict in
+  git, and are resolved manually. Accepted: writes are rare and single-owner by
+  construction
+- Nothing structurally prevents the body from degrading into an append-only log; only
+  the advisory size budget and human review push back
+- Two storage patterns now exist for git-native agent state, and contributors must know
+  which applies. Mitigated by the workload table above, which is the deciding test
+
+## References
+
+- [RFC-011: Agent Memory, Identity, and Resumability](../proposals/011-agent-memory-and-resumability.md)
+- [ADR-017: Event Log as Record, SQLite as Cache](017-event-log-task-graph.md) — the
+  adjacent decision this one deliberately diverges from
+- [ADR-001: Frontmatter Parsing Strategy](001-frontmatter-parsing-strategy.md)
+- [ADR-021: Manifest Checkpoint and Criterion-Level Acceptance](021-manifest-checkpoint-schema.md)
+- [Plan-010: Agent Memory and Resumability](../plans/010-agent-memory-and-resumability.md)

--- a/docs/decisions/021-manifest-checkpoint-schema.md
+++ b/docs/decisions/021-manifest-checkpoint-schema.md
@@ -1,0 +1,178 @@
+---
+title: "Manifest Checkpoint and Criterion-Level Acceptance Tracking"
+number: "021"
+status: accepted
+author: Alex
+created: 2026-07-28
+updated: 2026-07-28
+originating_proposal: "011"
+supersedes: null
+superseded_by: null
+---
+
+# ADR-021: Manifest Checkpoint and Criterion-Level Acceptance Tracking
+
+## Status
+
+Accepted
+
+<!-- Valid values: proposed, accepted, deprecated, superseded -->
+<!-- Once accepted, this document is IMMUTABLE. -->
+<!-- Exception: superseded_by may be updated when a new ADR supersedes this one. -->
+
+## Context
+
+ADR-008 established `.impl/manifest.json` as the single source of truth for
+orchestration state, with the hierarchy Plan → Phase → Task. It works: `/orchestrate
+--continue` resumes correctly at task granularity.
+
+Two things it cannot express surfaced in practice.
+
+**Reasoning does not survive a session.** The manifest records that task 2b is `failed`
+and has been retried twice. It cannot record _that retrying is the wrong move_ — that
+both failures were the same test failure, and the approach needs changing rather than
+repeating. A new session reads `failed, retries: 2` and does the obvious wrong thing.
+
+**Retry is all-or-nothing.** A task whose session dies at 80% restarts at zero. The
+manifest's smallest unit is the task, so 80% of the work is discarded along with the 20%
+that was missing. Tasks already carry acceptance criteria — as prose, in the task
+description — so the information needed to resume mid-task exists but is not addressable.
+
+The obvious fix for the second problem is a fourth hierarchy level, Plan → Phase → Task →
+Step. That is exactly what ADR-008's decomposition contract forbids, and it would change
+`/decompose`'s output shape and the `impl-worker` contract along with it.
+
+## Decision
+
+**Extend the manifest with two additive, optional fields. Neither changes the hierarchy,
+`/decompose`'s interface, nor the `impl-worker` contract.**
+
+### 1. A top-level `checkpoint` object
+
+```json
+{
+  "plan": { "path": "docs/plans/008-example.md" },
+  "checkpoint": {
+    "session_id": "sess-abc123",
+    "agent_id": "impl-worker",
+    "phase": 2,
+    "timestamp": "2026-07-28T14:30:00Z",
+    "orchestrator_summary": "Phase 1 complete (3/3 merged). Phase 2: task-2a passed, task-2b failed on the test suite twice — needs a different approach, not a retry. task-2c pending.",
+    "pending_decisions": [
+      "task-2b: response format — envelope vs flat. Blocked on review feedback."
+    ],
+    "environment_state": {
+      "active_worktrees": ["task-2a", "task-2b"],
+      "branches": { "task-2a": "impl/plan-008/task-2a" }
+    }
+  }
+}
+```
+
+The checkpoint carries natural-language reasoning that structured task state cannot.
+
+**The checkpoint is advisory; the manifest's task array remains authoritative.** A
+summary is written by a session that may have been failing when it wrote it, so it can
+describe a state that no longer holds or never held. Consumers treat it as context for
+the model, never as a source of truth for control flow. Where the two disagree, task
+state wins and the divergence is reported.
+
+### 2. Optional `acceptance_criteria` on a task
+
+```json
+{
+  "id": "2.1",
+  "status": "in_progress",
+  "acceptance_criteria": [
+    {
+      "description": "Middleware rejects missing auth with 401",
+      "verified": true,
+      "verified_at": "2026-07-28T14:20:00Z"
+    },
+    {
+      "description": "Valid tokens pass to next handler",
+      "verified": true,
+      "verified_at": "2026-07-28T14:22:00Z"
+    },
+    {
+      "description": "Unit tests cover both cases",
+      "verified": false,
+      "verified_at": null
+    }
+  ]
+}
+```
+
+A resumed worker skips verified criteria and continues from the first unverified one.
+This buys sub-task resumability by making an existing concept addressable rather than by
+adding a hierarchy level: criteria are a **property of a task**, not children of it.
+Tasks remain the unit of decomposition, spawning, validation, and merge.
+
+`/check-impl` continues to validate at task level. A task is not complete because its
+criteria are ticked; it is complete when its checks pass. Criteria are a resumption
+hint, not an acceptance gate.
+
+### Compatibility
+
+Both fields are absent from every existing manifest, and absence is valid. Consumers
+(`/orchestrate`, `/check-impl`, `/merge-work`, `/spawn`) must tolerate missing fields and
+must not fail on unknown ones. No migration runs; a manifest gains a checkpoint the first
+time something writes one.
+
+## Options Considered
+
+### Option 1: Additive optional manifest fields (chosen)
+
+Backward-compatible by construction, keeps one source of truth, and requires no change to
+decomposition or the worker contract.
+
+Cost: the manifest now holds prose alongside structured state, and prose can be stale in
+ways JSON fields are not. Bounded by making the checkpoint explicitly advisory.
+
+### Option 2: A fourth hierarchy level (Plan → Phase → Task → Step)
+
+Gives genuine sub-task tracking with clean semantics. Rejected: it breaks ADR-008's
+decomposition contract, changes `/decompose`'s output shape, changes the `impl-worker`
+contract, and forces every manifest consumer to handle a new nesting level — a large
+blast radius for something acceptance criteria already deliver.
+
+### Option 3: A separate checkpoint file (`.impl/checkpoint.json`)
+
+Keeps the manifest schema untouched. Rejected: two files describing one execution can
+disagree, and there is no atomic write across them. ADR-008 chose a single manifest
+precisely to avoid this, and nothing here justifies reversing it.
+
+### Option 4: Reconstruct reasoning from conversation history
+
+No schema change at all. Rejected: history is not git-native, not reviewable, and not
+available to a fresh session in another clone — which is the case resumability exists to
+serve.
+
+## Consequences
+
+### Positive
+
+- A resumed session inherits reasoning, not just state — including the knowledge that a
+  retry is the wrong move
+- A task 80% complete resumes at 80%
+- Fully backward compatible; existing manifests remain valid and untouched
+- The DDD hierarchy, `/decompose`, and the `impl-worker` contract are all unchanged
+- One source of truth is preserved, per ADR-008
+
+### Negative
+
+- Manifests grow, and `orchestrator_summary` is unbounded prose in a state file
+- A stale checkpoint can mislead a resumed session; mitigated by advisory status and
+  divergence reporting, not eliminated
+- Four manifest consumers must tolerate the new fields, and the no-jq fallback paths in
+  `task-manifest.sh` grow correspondingly
+- `verified: true` is asserted by the agent that did the work, so it is a claim rather
+  than a proof. `/check-impl` remains the actual gate
+
+## References
+
+- [RFC-011: Agent Memory, Identity, and Resumability](../proposals/011-agent-memory-and-resumability.md)
+- [ADR-008: Manifest-Driven Orchestration State](008-manifest-driven-orchestration-state.md) — extended, not superseded
+- [ADR-007: Worktree Isolation for Task Execution](007-worktree-isolation-for-task-execution.md)
+- [ADR-020: Agent Memory as a Frontmatter Document](020-agent-memory-as-document.md)
+- [Plan-010: Agent Memory and Resumability](../plans/010-agent-memory-and-resumability.md)

--- a/docs/plans/010-agent-memory-and-resumability.md
+++ b/docs/plans/010-agent-memory-and-resumability.md
@@ -1,7 +1,7 @@
 ---
 title: "Agent Memory and Resumability"
 number: "010"
-status: active
+status: complete
 author: Alex
 created: 2026-07-28
 updated: 2026-07-28
@@ -74,54 +74,54 @@ carry memory live in three different plugins that cannot depend on one another.
 
 ### Phase 1: principled-agent plugin foundation
 
-- [ ] Create plugin skeleton: `.claude-plugin/plugin.json`, `README.md`
-- [ ] Implement `lib/agent-memory.sh` — init, show, update-metrics, reset-metrics,
+- [x] Create plugin skeleton: `.claude-plugin/plugin.json`, `README.md`
+- [x] Implement `lib/agent-memory.sh` — init, show, update-metrics, reset-metrics,
       list, path resolution; bash 3.2 clean, jq-optional
-- [ ] Define the `.agents/` scaffold and `registry.json` schema, seeded with the three
+- [x] Define the `.agents/` scaffold and `registry.json` schema, seeded with the three
       memory-bearing agents (`impl-worker`, `issue-ingester`, `pr-reviewer`)
-- [ ] Add the plugin to `.claude-plugin/marketplace.json`
+- [x] Add the plugin to `.claude-plugin/marketplace.json`
 
 ### Phase 2: principled-agent skills and hooks
 
-- [ ] `agent-strategy` — background knowledge skill (not user-invocable)
-- [ ] `/agent-init` — scaffold `.agents/` in a repository
-- [ ] `/agent-memory` — show, edit, and reset metrics for an agent's memory
-- [ ] `/agent-retro` — write a post-execution retrospective
-- [ ] `hooks/scripts/inject-agent-memory.sh` — surface memory at spawn; advisory,
+- [x] `agent-strategy` — background knowledge skill (not user-invocable)
+- [x] `/agent-init` — scaffold `.agents/` in a repository
+- [x] `/agent-memory` — show, edit, and reset metrics for an agent's memory
+- [x] `/agent-retro` — write a post-execution retrospective
+- [x] `hooks/scripts/inject-agent-memory.sh` — surface memory at spawn; advisory,
       always exits 0, never truncates
-- [ ] `hooks/scripts/check-memory-integrity.sh` — validate frontmatter and enforce the
+- [x] `hooks/scripts/check-memory-integrity.sh` — validate frontmatter and enforce the
       8 KB / 16 KB advisory size budget; always exits 0
-- [ ] `hooks/hooks.json` wiring both hooks
+- [x] `hooks/hooks.json` wiring both hooks
 
 ### Phase 3: manifest checkpoint and acceptance criteria
 
-- [ ] Extend `lib/task-manifest.sh` with `--set-checkpoint` and `--get-checkpoint`,
+- [x] Extend `lib/task-manifest.sh` with `--set-checkpoint` and `--get-checkpoint`,
       including the no-jq fallback
-- [ ] Extend `lib/task-manifest.sh` with `--set-criteria`, `--verify-criterion`, and
+- [x] Extend `lib/task-manifest.sh` with `--set-criteria`, `--verify-criterion`, and
       `--list-criteria`
-- [ ] Confirm `/orchestrate`, `/check-impl`, `/merge-work`, and `/spawn` tolerate both
+- [x] Confirm `/orchestrate`, `/check-impl`, `/merge-work`, and `/spawn` tolerate both
       new fields and unknown fields
-- [ ] Update `skills/impl-strategy/reference/manifest-schema.md`
+- [x] Update `skills/impl-strategy/reference/manifest-schema.md`
 
 ### Phase 4: the /resume skill
 
-- [ ] `/resume [plan-path] [--from-checkpoint] [--replan]`
-- [ ] Divergence report against principled-tasks, degrading silently when the plugin or
+- [x] `/resume [plan-path] [--from-checkpoint] [--replan]`
+- [x] Divergence report against principled-tasks, degrading silently when the plugin or
       `.principled/tasks.jsonl` is absent
-- [ ] Document that the checkpoint is advisory and task state is authoritative
+- [x] Document that the checkpoint is advisory and task state is authoritative
 
 ### Phase 5: tests, docs, and CI
 
-- [ ] `tests/agent-memory.bats` — lib behaviour, frontmatter round-trip, size budget,
+- [x] `tests/agent-memory.bats` — lib behaviour, frontmatter round-trip, size budget,
       metrics reset
-- [ ] Extend `tests/hooks.bats` for both new hooks, including the no-jq path
-- [ ] `tests/manifest-checkpoint.bats` — checkpoint and criteria, with and without jq
-- [ ] `docs/architecture/agent-memory.md` — the `.agents/` contract and injection points
-- [ ] Update `docs/architecture/documentation-pipeline.md` for memory and retrospectives
+- [x] Extend `tests/hooks.bats` for both new hooks, including the no-jq path
+- [x] `tests/manifest-checkpoint.bats` — checkpoint and criteria, with and without jq
+- [x] `docs/architecture/agent-memory.md` — the `.agents/` contract and injection points
+- [x] Update `docs/architecture/documentation-pipeline.md` for memory and retrospectives
       as document types
-- [ ] Update root `CLAUDE.md` and `.claude/CLAUDE.md`; correct the stale claim that the
+- [x] Update root `CLAUDE.md` and `.claude/CLAUDE.md`; correct the stale claim that the
       `lib/` migration is still in progress
-- [ ] `just ci` green
+- [x] `just ci` green
 
 ## Dependencies
 
@@ -136,15 +136,35 @@ No RFC-008 dependency. RFC-012 and RFC-013 depend on this plan, not the reverse.
 
 ## Acceptance Criteria
 
-- [ ] `principled-agent` is installable and listed in the marketplace manifest
-- [ ] `.agents/` scaffolds with a valid registry and memory files for the three
+- [x] `principled-agent` is installable and listed in the marketplace manifest
+- [x] `.agents/` scaffolds with a valid registry and memory files for the three
       memory-bearing agents
-- [ ] Memory files parse with the existing frontmatter tooling
-- [ ] The integrity hook warns past 8 KB and never blocks; injection never truncates
-- [ ] `--reset-metrics` clears counters while leaving the body intact
-- [ ] A manifest with a checkpoint and criteria is readable by every existing consumer,
+- [x] Memory files parse with the existing frontmatter tooling
+- [x] The integrity hook warns past 8 KB and never blocks; injection never truncates
+- [x] `--reset-metrics` clears counters while leaving the body intact
+- [x] A manifest with a checkpoint and criteria is readable by every existing consumer,
       and a manifest without them still works unchanged
-- [ ] `/resume` reports divergence against the task graph and exits 0, including when
+- [x] `/resume` reports divergence against the task graph and exits 0, including when
       principled-tasks is not installed
-- [ ] Every new script passes ShellCheck and shfmt, and runs on bash 3.2
-- [ ] `just ci` passes
+- [x] Every new script passes ShellCheck and shfmt, and runs on bash 3.2
+- [x] `just ci` passes
+
+## Verification
+
+Machine-tested by `just ci` (126 bats tests, each new operation run both with jq and
+with a PATH that genuinely lacks it):
+
+- `lib/agent-memory.sh` — scaffold, metrics arithmetic, reset, size budget, structural
+  integrity, both output formats (`tests/agent-memory.bats`)
+- both principled-agent hooks — injection content, no-truncation, silence for
+  non-memory agents, malformed input, no-jq path (`tests/hooks.bats`)
+- manifest checkpoint and criteria — round-trip, overwrite, clear, range checking, and
+  cross-compatibility between the jq and no-jq writers (`tests/manifest-checkpoint.bats`)
+
+Delivered as skills, and therefore model-executed rather than machine-tested: `/resume`,
+`/agent-init`, `/agent-memory`, `/agent-retro`. Their script dependencies are covered
+above; the workflow prose is not executable and is not claimed to be tested.
+
+Fixed in passing: five `sed -i` calls in `task-manifest.sh`'s no-jq fallback. BSD sed
+reads the following argument as a backup suffix, so adding a second task and every
+status update failed on stock macOS. Replaced with awk, pinned by regression tests.

--- a/docs/plans/010-agent-memory-and-resumability.md
+++ b/docs/plans/010-agent-memory-and-resumability.md
@@ -1,0 +1,150 @@
+---
+title: "Agent Memory and Resumability"
+number: "010"
+status: active
+author: Alex
+created: 2026-07-28
+updated: 2026-07-28
+originating_proposal: "011"
+related_adrs: ["020", "021"]
+---
+
+# Plan-010: Agent Memory and Resumability
+
+## Objective
+
+Implements [RFC-011](../proposals/011-agent-memory-and-resumability.md).
+
+Deliver persistent agent memory and resumable orchestration: a new `principled-agent`
+plugin owning the `.agents/` directory and its injection and integrity hooks, plus
+additive extensions to principled-implementation's manifest for checkpointing and
+criterion-level acceptance tracking.
+
+Scope is agent state — properties of the worker. Work tracking stays delegated to
+principled-tasks (ADR-017), per RFC-011.
+
+## Related Decisions
+
+- [ADR-020: Agent Memory as a Frontmatter Document](../decisions/020-agent-memory-as-document.md) —
+  memory is a revisable markdown document, not an event log
+- [ADR-021: Manifest Checkpoint and Criterion-Level Acceptance](../decisions/021-manifest-checkpoint-schema.md) —
+  two additive optional manifest fields, no hierarchy change
+- [ADR-008: Manifest-Driven Orchestration State](../decisions/008-manifest-driven-orchestration-state.md) — extended
+- [ADR-018: Shared Plugin lib/ Over Copies](../decisions/018-shared-plugin-lib-over-copies.md) —
+  shared code goes in the plugin's `lib/`
+- [ADR-003: Module Type Declaration via CLAUDE.md](../decisions/003-module-type-storage.md)
+
+## Domain Analysis
+
+### Bounded Contexts
+
+**Agent Identity** (`principled-agent`) — who an agent is and what it has learned.
+Owns `.agents/registry.json`, `.agents/memory/`, and `.agents/retrospectives/`. Knows
+nothing about plans, tasks, or manifests.
+
+**Orchestration State** (`principled-implementation`) — what execution has happened and
+what remains. Owns `.impl/manifest.json`, now including the checkpoint and per-task
+acceptance criteria.
+
+**Work Backlog** (`principled-tasks`, existing) — the task graph. Read-only from this
+plan's perspective; `/resume` correlates against it but never writes to it.
+
+The seam between the first two is deliberate: memory is a property of the worker, the
+checkpoint is a property of the work. They are separate plugins because the agents that
+carry memory live in three different plugins that cannot depend on one another.
+
+### Aggregates
+
+| Aggregate           | Root                            | Invariants                                                        |
+| ------------------- | ------------------------------- | ----------------------------------------------------------------- |
+| Agent Memory        | `.agents/memory/agents/<id>.md` | Valid frontmatter; `agent_id` matches filename; body is prose     |
+| Agent Registry      | `.agents/registry.json`         | One entry per agent; `memory: true` implies a memory file exists  |
+| Manifest Checkpoint | `.impl/manifest.json`           | Advisory; task array stays authoritative; absence is valid        |
+| Acceptance Criteria | a task within the manifest      | `verified: true` implies non-null `verified_at`; absence is valid |
+
+### Domain Events
+
+- **AgentSpawned** → memory is injected into the agent's context
+- **SessionEnded** → checkpoint written with reasoning summary
+- **CriterionVerified** → criterion flipped to `verified`, timestamp stamped
+- **MemoryWritten** → integrity hook checks frontmatter and size budget
+- **ResumeRequested** → checkpoint read, divergence against the task graph reported
+
+## Implementation Tasks
+
+### Phase 1: principled-agent plugin foundation
+
+- [ ] Create plugin skeleton: `.claude-plugin/plugin.json`, `README.md`
+- [ ] Implement `lib/agent-memory.sh` — init, show, update-metrics, reset-metrics,
+      list, path resolution; bash 3.2 clean, jq-optional
+- [ ] Define the `.agents/` scaffold and `registry.json` schema, seeded with the three
+      memory-bearing agents (`impl-worker`, `issue-ingester`, `pr-reviewer`)
+- [ ] Add the plugin to `.claude-plugin/marketplace.json`
+
+### Phase 2: principled-agent skills and hooks
+
+- [ ] `agent-strategy` — background knowledge skill (not user-invocable)
+- [ ] `/agent-init` — scaffold `.agents/` in a repository
+- [ ] `/agent-memory` — show, edit, and reset metrics for an agent's memory
+- [ ] `/agent-retro` — write a post-execution retrospective
+- [ ] `hooks/scripts/inject-agent-memory.sh` — surface memory at spawn; advisory,
+      always exits 0, never truncates
+- [ ] `hooks/scripts/check-memory-integrity.sh` — validate frontmatter and enforce the
+      8 KB / 16 KB advisory size budget; always exits 0
+- [ ] `hooks/hooks.json` wiring both hooks
+
+### Phase 3: manifest checkpoint and acceptance criteria
+
+- [ ] Extend `lib/task-manifest.sh` with `--set-checkpoint` and `--get-checkpoint`,
+      including the no-jq fallback
+- [ ] Extend `lib/task-manifest.sh` with `--set-criteria`, `--verify-criterion`, and
+      `--list-criteria`
+- [ ] Confirm `/orchestrate`, `/check-impl`, `/merge-work`, and `/spawn` tolerate both
+      new fields and unknown fields
+- [ ] Update `skills/impl-strategy/reference/manifest-schema.md`
+
+### Phase 4: the /resume skill
+
+- [ ] `/resume [plan-path] [--from-checkpoint] [--replan]`
+- [ ] Divergence report against principled-tasks, degrading silently when the plugin or
+      `.principled/tasks.jsonl` is absent
+- [ ] Document that the checkpoint is advisory and task state is authoritative
+
+### Phase 5: tests, docs, and CI
+
+- [ ] `tests/agent-memory.bats` — lib behaviour, frontmatter round-trip, size budget,
+      metrics reset
+- [ ] Extend `tests/hooks.bats` for both new hooks, including the no-jq path
+- [ ] `tests/manifest-checkpoint.bats` — checkpoint and criteria, with and without jq
+- [ ] `docs/architecture/agent-memory.md` — the `.agents/` contract and injection points
+- [ ] Update `docs/architecture/documentation-pipeline.md` for memory and retrospectives
+      as document types
+- [ ] Update root `CLAUDE.md` and `.claude/CLAUDE.md`; correct the stale claim that the
+      `lib/` migration is still in progress
+- [ ] `just ci` green
+
+## Dependencies
+
+All shipped; nothing here is blocked:
+
+- Worktree isolation (ADR-007) and manifest state (ADR-008)
+- principled-tasks (ADR-017) — optional at runtime, for correlation only
+- `parse-frontmatter.sh` in principled-docs — the pattern for frontmatter reads
+- Bash 3.2 and jq-optional constraints apply to every script
+
+No RFC-008 dependency. RFC-012 and RFC-013 depend on this plan, not the reverse.
+
+## Acceptance Criteria
+
+- [ ] `principled-agent` is installable and listed in the marketplace manifest
+- [ ] `.agents/` scaffolds with a valid registry and memory files for the three
+      memory-bearing agents
+- [ ] Memory files parse with the existing frontmatter tooling
+- [ ] The integrity hook warns past 8 KB and never blocks; injection never truncates
+- [ ] `--reset-metrics` clears counters while leaving the body intact
+- [ ] A manifest with a checkpoint and criteria is readable by every existing consumer,
+      and a manifest without them still works unchanged
+- [ ] `/resume` reports divergence against the task graph and exits 0, including when
+      principled-tasks is not installed
+- [ ] Every new script passes ShellCheck and shfmt, and runs on bash 3.2
+- [ ] `just ci` passes

--- a/docs/proposals/011-agent-memory-and-resumability.md
+++ b/docs/proposals/011-agent-memory-and-resumability.md
@@ -1,7 +1,7 @@
 ---
 title: "Agent Memory, Identity, and Resumability"
 number: "011"
-status: draft
+status: accepted
 author: Alex
 created: 2026-07-28
 updated: 2026-07-28
@@ -281,15 +281,92 @@ granularity with no contract change.
   ADR-017's event log
 - **New ADR:** manifest checkpoint schema, extending ADR-008
 
-## Open Questions
+## Resolved Questions
 
-- **Memory pruning.** At what size does a memory file stop helping and start diluting
-  context? Is pruning periodic, size-triggered, or an explicit `/improve` step?
-- **Memory and forks.** Should identity and memory carry across a repository fork?
-  Codebase knowledge transfers; performance metrics probably do not. A reasonable
-  default: memory transfers, registry metrics reset.
-- **Correlating with principled-tasks.** Tasks carry `plan` and `task_id` fields
-  intended to line up with the manifest, but nothing verifies the correspondence.
-  Should `/resume` reconcile the two, and what does it do when they disagree?
-- **Does `.agents/` belong in a new plugin at all**, or should memory live in
-  principled-implementation alongside the manifest it extends?
+These were open when this proposal was drafted. Each is answered below; the answers are
+binding on the implementation plan.
+
+### Memory pruning
+
+**Resolved: a soft size budget, warned advisorily, remedied by synthesis — never by
+automatic truncation.**
+
+The cost of an oversized memory file is not storage, it is context budget: every byte
+injected at spawn competes with the task description. The budget is therefore expressed
+in the unit that matters, and set where a file still reads as curated knowledge rather
+than a log:
+
+| Threshold     | Behaviour                                             |
+| ------------- | ----------------------------------------------------- |
+| under 8 KB    | silent                                                |
+| 8 KB to 16 KB | `check-memory-integrity.sh` warns, suggests synthesis |
+| over 16 KB    | warns more loudly; injection still proceeds           |
+
+Injection is never silently truncated. Dropping the second half of a memory file would
+give an agent a confidently incomplete picture — worse than a large file, because the
+loss is invisible. Pruning stays an explicit, reviewable act.
+
+Automatic synthesis is **out of scope here** and belongs to `/improve` (RFC-013).
+Until that ships, the remedy is a human editing the file, which is exactly the
+reviewability this proposal argues for. Shipping a warning without an automatic fix is
+the honest position: we can detect dilution, and we cannot yet safely cure it.
+
+### Memory and forks
+
+**Resolved: memory transfers, registry metrics reset — on explicit command, not by
+detection.**
+
+Because `.agents/` is committed, a fork inherits everything by default. The question is
+only what _should not_ survive, and that is the performance data: `session_count`,
+`total_tasks`, and `success_rate` describe an agent's record against the parent
+repository's codebase and CI, and carrying them into a fork makes a fresh agent look
+seasoned.
+
+Fork detection is unreliable — a fork, a template instantiation, and a plain clone are
+not distinguishable from inside the repository — so the reset is a command, not an
+inference:
+
+```
+agent-memory.sh --reset-metrics [--agent <id>]
+```
+
+Knowledge in the markdown body always transfers. It describes the code, which the fork
+still has.
+
+### Correlating with principled-tasks
+
+**Resolved: `/resume` reports divergence and never reconciles it silently.**
+
+Two records exist and each is authoritative for its own domain: the manifest owns
+implementation state (ADR-008), and the task graph owns the backlog (ADR-017). Neither
+may overwrite the other, because a disagreement between them is evidence — usually that
+a session died between writing one and writing the other — and auto-reconciling would
+destroy exactly the signal a human needs to see.
+
+`/resume` therefore joins on `plan` plus `task_id` and prints a divergence report:
+manifest tasks with no graph task, graph tasks with no manifest task, and status
+disagreements. It exits successfully regardless; divergence is information, not failure.
+
+principled-tasks is an independent install, so this correlation is **conditional**. When
+the plugin is absent or `.principled/tasks.jsonl` does not exist, `/resume` skips the
+section silently rather than erroring.
+
+### Where `.agents/` lives
+
+**Resolved: a new `principled-agent` plugin.**
+
+The decisive constraint is that the three memory-bearing agents live in three different
+plugins — `impl-worker` in principled-implementation, `issue-ingester` in
+principled-github, `pr-reviewer` in principled-quality — and plugins install
+independently and cannot reference each other's `${CLAUDE_PLUGIN_ROOT}` (the same
+constraint that keeps three copies of `check-gh-cli.sh` alive). Housing memory in
+principled-implementation would make GitHub and quality agents depend on a plugin they
+have no other reason to install.
+
+`.agents/` itself is a repository-root convention, not a plugin-internal path, so any
+plugin can read it. What belongs to the new plugin is the code that manages it: the
+registry, the injection hook, and the integrity check.
+
+The split is therefore along ownership, matching the Delivery table above: state _about
+the worker_ goes to principled-agent; state _about the work_ — checkpoint, acceptance
+criteria, `/resume` — stays in principled-implementation with the manifest it extends.

--- a/plugins/principled-agent/.claude-plugin/plugin.json
+++ b/plugins/principled-agent/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "principled-agent",
+  "version": "0.1.0",
+  "description": "Persistent agent identity and memory. Git-committed, reviewable knowledge that agents accumulate across sessions, injected at spawn and revised in pull requests.",
+  "author": "Alex Nodeland",
+  "homepage": "https://github.com/alexnodeland/principled",
+  "keywords": [
+    "agent",
+    "memory",
+    "identity",
+    "resumability",
+    "orchestration",
+    "retrospective"
+  ]
+}

--- a/plugins/principled-agent/README.md
+++ b/plugins/principled-agent/README.md
@@ -1,0 +1,138 @@
+# principled-agent
+
+Persistent agent identity and memory for the Principled methodology.
+
+Agents start fresh every session. An `impl-worker` that learned this codebase uses
+barrel exports relearns it on the next task, and the one after that. This plugin gives
+agents a git-committed, reviewable place to keep what they have learned, and injects it
+when they spawn.
+
+Implements [RFC-011](../../docs/proposals/011-agent-memory-and-resumability.md).
+
+## What it is not
+
+This plugin tracks **state about the worker**, not state about the work.
+
+- The backlog — what needs doing, what blocks what — belongs to
+  [principled-tasks](../principled-tasks) (ADR-017).
+- Execution state — which task is in progress, which merged — belongs to
+  [principled-implementation](../principled-implementation) (ADR-008).
+
+If a fact would still be true after every open task closed, it is memory. Otherwise it
+belongs to one of the other two.
+
+## Install
+
+```
+/plugin marketplace add alexnodeland/principled
+/plugin install principled-agent
+```
+
+## Quick start
+
+```bash
+/agent-init                          # scaffold .agents/
+/agent-memory --list                 # what each agent knows, and how big it is
+/agent-memory impl-worker            # read one agent's memory
+/agent-retro docs/plans/008-....md   # retrospective after an orchestration run
+```
+
+## Skills
+
+| Skill            | Command                                             | Category   |
+| ---------------- | --------------------------------------------------- | ---------- |
+| `agent-strategy` | _(background — not user-invocable)_                 | Knowledge  |
+| `agent-init`     | `/agent-init [--commit]`                            | Generative |
+| `agent-memory`   | `/agent-memory [<id>] [--list] [--learn] [--check]` | Analytical |
+| `agent-retro`    | `/agent-retro [<plan-path>] [--promote]`            | Generative |
+
+## Hooks
+
+| Hook                      | Event                     | Behaviour                                      |
+| ------------------------- | ------------------------- | ---------------------------------------------- |
+| Agent Memory Injection    | SubagentStart             | Surfaces memory at spawn; always exits 0       |
+| Memory Integrity Advisory | PostToolUse (Edit\|Write) | Validates frontmatter and size; always exits 0 |
+
+Neither hook ever blocks. A problem with memory must not prevent an agent from running.
+
+## Layout
+
+```
+.agents/
+  registry.json          # who exists, who carries memory, and why
+  memory/
+    global.md            # applies to every agent
+    agents/<id>.md       # one file per memory-bearing agent
+  retrospectives/        # dated records of individual runs
+```
+
+`.agents/` is committed. It is team knowledge, reviewed in pull requests like any other
+document — which is what makes a bad learned pattern visible before it merges and
+revertable after.
+
+## The context budget
+
+Every byte of memory is injected at spawn and competes with the task description.
+
+| Size         | Behaviour                                       |
+| ------------ | ----------------------------------------------- |
+| under 8 KB   | silent                                          |
+| 8 KB – 16 KB | advisory warning, synthesis suggested           |
+| over 16 KB   | louder warning; injection still delivers it all |
+
+**Injection is never truncated.** A silently halved memory file gives an agent a
+confidently incomplete picture, and the loss is invisible to it. The cure is synthesis —
+rewriting many notes into fewer, denser statements — which requires judgment and so
+stays a human act for now. RFC-013's `/improve` will automate it.
+
+## Format
+
+Markdown with YAML frontmatter, one file per agent ([ADR-020](../../docs/decisions/020-agent-memory-as-document.md)):
+
+```markdown
+---
+agent_id: "impl-worker"
+role: worker
+last_updated: 2026-07-28
+session_count: 12
+total_tasks: 47
+success_rate: 0.91
+specializations: ["bash", "hook-authoring"]
+---
+
+# impl-worker — Accumulated Knowledge
+
+## Known Patterns
+
+- Shared scripts live in each plugin's `lib/`, referenced via `${CLAUDE_PLUGIN_ROOT}`
+  (ADR-018). Never copy one into a skill directory.
+- macOS ships bash 3.2. No `declare -A`, no `local -n`, no `grep -P`.
+```
+
+Memory is **revised, not appended**. A learning that turns out to be wrong is edited out
+and git records that it was ever believed. That is the deliberate difference from
+ADR-017's event log, where past entries are immutable — a wrong learned pattern that
+cannot be deleted compounds on every spawn.
+
+Metric fields are script-owned. Use `--update-metrics`, don't hand-edit them.
+
+## Forks
+
+`.agents/` is committed, so a fork inherits everything. Knowledge should transfer;
+performance history should not. Fork detection is unreliable, so the reset is explicit:
+
+```bash
+bash lib/agent-memory.sh --reset-metrics
+```
+
+## Requirements
+
+- Claude Code v2.1.3+
+- Bash 3.2+ (stock macOS)
+- jq optional — every script falls back to grep and awk
+
+## Decisions
+
+- [ADR-020: Agent Memory as a Frontmatter Document](../../docs/decisions/020-agent-memory-as-document.md)
+- [ADR-021: Manifest Checkpoint and Criterion-Level Acceptance](../../docs/decisions/021-manifest-checkpoint-schema.md)
+- [ADR-018: Shared Plugin lib/ Over Copies](../../docs/decisions/018-shared-plugin-lib-over-copies.md)

--- a/plugins/principled-agent/hooks/hooks.json
+++ b/plugins/principled-agent/hooks/hooks.json
@@ -1,0 +1,28 @@
+{
+  "description": "Principled agent: memory injection at spawn and integrity advisory for .agents/ writes",
+  "hooks": {
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/inject-agent-memory.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/check-memory-integrity.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/principled-agent/hooks/scripts/check-memory-integrity.sh
+++ b/plugins/principled-agent/hooks/scripts/check-memory-integrity.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# check-memory-integrity.sh — Advisory integrity check for agent memory files
+#
+# Fires after a write to anything under .agents/. Validates frontmatter structure
+# and reports against the context budget from RFC-011:
+#
+#   under 8 KB      silent
+#   8 KB to 16 KB   warn, suggest synthesis
+#   over 16 KB      warn loudly
+#
+# The budget is about context, not disk: every byte is injected at spawn and
+# competes with the task description. It is advisory because the cure — synthesis
+# — requires judgment this script does not have.
+#
+# Input: JSON on stdin with tool_input.file_path
+# Output: Warnings to stderr
+# Exit: Always 0 (advisory)
+
+set -euo pipefail
+
+SOFT_LIMIT_BYTES=8192
+HARD_LIMIT_BYTES=16384
+
+input=$(cat 2> /dev/null || true)
+
+file_path=""
+if command -v jq &> /dev/null; then
+  file_path=$(echo "$input" | jq -r '.tool_input.file_path // empty' 2> /dev/null || true)
+else
+  file_path=$(echo "$input" \
+    | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' \
+    | head -1 \
+    | sed 's/.*"file_path"[[:space:]]*:[[:space:]]*"//' \
+    | sed 's/"$//' || true)
+fi
+
+if [[ -z "$file_path" ]]; then
+  exit 0
+fi
+
+# Only concerned with agent state.
+case "$file_path" in
+*/.agents/* | .agents/*) ;;
+*) exit 0 ;;
+esac
+
+# The registry is JSON, not a memory document — different checks apply.
+if [[ "$file_path" == *"registry.json"* ]]; then
+  if [[ -f "$file_path" ]] && command -v jq &> /dev/null; then
+    if ! jq . "$file_path" > /dev/null 2>&1; then
+      echo "⚠️  Advisory: .agents/registry.json is not valid JSON." >&2
+      echo "   Agent lookup and memory injection will silently skip agents until this parses." >&2
+    fi
+  fi
+  exit 0
+fi
+
+# Retrospectives are prose; no budget applies.
+case "$file_path" in
+*/retrospectives/*) exit 0 ;;
+esac
+
+# Only memory markdown files past this point.
+case "$file_path" in
+*.md) ;;
+*) exit 0 ;;
+esac
+
+if [[ ! -f "$file_path" ]]; then
+  exit 0
+fi
+
+# --- Frontmatter structure -------------------------------------------------
+if [[ "$(head -1 "$file_path")" != "---" ]]; then
+  echo "⚠️  Advisory: ${file_path} has no YAML frontmatter." >&2
+  echo "   Memory files are frontmatter + markdown (ADR-020). Without frontmatter," >&2
+  echo "   metrics and integrity checks cannot read this file." >&2
+  exit 0
+fi
+
+# The agent_id must match the filename, or injection will look up the wrong file.
+base="$(basename "$file_path" .md)"
+case "$file_path" in
+*/memory/agents/*)
+  declared="$(awk '
+    NR == 1 && /^---[[:space:]]*$/ { infm = 1; next }
+    infm && /^---[[:space:]]*$/ { exit }
+    infm && /^agent_id:/ {
+      v = $0
+      sub(/^agent_id:[[:space:]]*/, "", v)
+      gsub(/^"|"$/, "", v)
+      print v
+      exit
+    }
+  ' "$file_path")"
+
+  if [[ -n "$declared" && "$declared" != "$base" ]]; then
+    echo "⚠️  Advisory: ${file_path} declares agent_id '${declared}' but is named '${base}.md'." >&2
+    echo "   Memory is looked up by filename, so this file will never be injected for" >&2
+    echo "   '${declared}'. Rename the file or correct the frontmatter." >&2
+  fi
+  ;;
+esac
+
+# --- Context budget --------------------------------------------------------
+size="$(wc -c < "$file_path" | awk '{print $1}')"
+
+if [[ "$size" -gt "$HARD_LIMIT_BYTES" ]]; then
+  echo "⚠️  Advisory: ${file_path} is ${size} bytes, well over the ${HARD_LIMIT_BYTES} byte budget." >&2
+  echo "   Every byte is injected at spawn and competes with the task description." >&2
+  echo "   Synthesize it into fewer, denser statements — injection is never truncated," >&2
+  echo "   so this file will be delivered in full at whatever size it reaches." >&2
+elif [[ "$size" -gt "$SOFT_LIMIT_BYTES" ]]; then
+  echo "⚠️  Advisory: ${file_path} is ${size} bytes, over the ${SOFT_LIMIT_BYTES} byte soft budget." >&2
+  echo "   Consider synthesizing accumulated notes into fewer, denser statements." >&2
+fi
+
+exit 0

--- a/plugins/principled-agent/hooks/scripts/inject-agent-memory.sh
+++ b/plugins/principled-agent/hooks/scripts/inject-agent-memory.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# inject-agent-memory.sh — Surface accumulated agent memory at spawn (ADR-020)
+#
+# Fires on SubagentStart. Lifecycle events do not support matchers (ADR-015), so
+# this script filters for agents that carry memory and exits quietly otherwise.
+#
+# Memory is written to stderr, which Claude Code returns to the agent as context.
+# Global memory is emitted first, then the agent's own file.
+#
+# Injection is never truncated. An agent given a silently halved memory file has a
+# confidently incomplete picture, which is worse than a large file because the loss
+# is invisible. Oversized files are reported by check-memory-integrity.sh instead.
+#
+# Input: JSON on stdin, with the spawning agent's identifier
+# Output: memory content to stderr
+# Exit: Always 0 (advisory — a memory problem must never block a spawn)
+
+set -euo pipefail
+
+input=$(cat 2> /dev/null || true)
+
+# --- Extract the agent identifier ------------------------------------------
+# The field name has varied across Claude Code versions, so try the plausible
+# ones rather than depending on one spelling.
+agent_id=""
+extract_field() {
+  local field="$1"
+  if command -v jq &> /dev/null; then
+    echo "$input" | jq -r ".${field} // .tool_input.${field} // empty" 2> /dev/null || true
+  else
+    echo "$input" \
+      | grep -o "\"${field}\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" \
+      | head -1 \
+      | sed "s/.*\"${field}\"[[:space:]]*:[[:space:]]*\"//" \
+      | sed 's/"$//' || true
+  fi
+}
+
+for field in agent_id subagent_type agent_type agent; do
+  agent_id="$(extract_field "$field")"
+  if [[ -n "$agent_id" ]]; then
+    break
+  fi
+done
+
+# Nothing to do if we cannot tell who is spawning.
+if [[ -z "$agent_id" ]]; then
+  exit 0
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2> /dev/null || pwd)"
+AGENTS_DIR="${REPO_ROOT}/.agents"
+GLOBAL_MEMORY="${AGENTS_DIR}/memory/global.md"
+AGENT_MEMORY="${AGENTS_DIR}/memory/agents/${agent_id}.md"
+
+# Not every repository has been initialized.
+if [[ ! -d "$AGENTS_DIR" ]]; then
+  exit 0
+fi
+
+# Only agents the registry marks memory:true receive anything — including global
+# memory. An agent that runs a deterministic script learns nothing by definition
+# (RFC-011), so injecting conventions into it spends context budget for no benefit.
+# Absent an agent memory file, this agent is not a memory-bearing one.
+if [[ ! -f "$AGENT_MEMORY" ]]; then
+  exit 0
+fi
+
+# Print everything after the closing frontmatter delimiter. Frontmatter is
+# metadata for scripts; the agent only needs the prose.
+emit_body() {
+  local file="$1"
+  [[ -f "$file" ]] || return 0
+  if [[ "$(head -1 "$file")" != "---" ]]; then
+    cat "$file"
+    return 0
+  fi
+  awk '
+    NR == 1 { next }
+    !done && /^---[[:space:]]*$/ { done = 1; next }
+    done { print }
+  ' "$file"
+}
+
+{
+  echo "=== Accumulated memory for '${agent_id}' ==="
+  echo "Source: .agents/memory/ (committed to git, revisable in review — ADR-020)"
+  echo ""
+
+  if [[ -f "$GLOBAL_MEMORY" ]]; then
+    echo "--- Global (applies to every agent) ---"
+    emit_body "$GLOBAL_MEMORY"
+    echo ""
+  fi
+
+  if [[ -f "$AGENT_MEMORY" ]]; then
+    echo "--- ${agent_id} ---"
+    emit_body "$AGENT_MEMORY"
+    echo ""
+  fi
+
+  echo "=== End memory ==="
+} >&2
+
+exit 0

--- a/plugins/principled-agent/lib/agent-memory.sh
+++ b/plugins/principled-agent/lib/agent-memory.sh
@@ -1,0 +1,598 @@
+#!/usr/bin/env bash
+# agent-memory.sh — Agent identity and memory interface (ADR-020)
+#
+# Memory is a markdown document with YAML frontmatter, one file per agent,
+# committed to git and revised in place. Frontmatter carries queryable metadata;
+# the body carries knowledge the model reads directly.
+#
+# Usage:
+#   agent-memory.sh --init [--root <path>]
+#   agent-memory.sh --path --agent <id>
+#   agent-memory.sh --show --agent <id> [--body-only|--frontmatter-only]
+#   agent-memory.sh --list [--format table|json]
+#   agent-memory.sh --update-metrics --agent <id> [--session] [--tasks N] [--succeeded N]
+#   agent-memory.sh --reset-metrics [--agent <id>]
+#   agent-memory.sh --check [--agent <id>]
+#
+# Exit codes:
+#   0 — success
+#   1 — error (unknown agent, malformed input, missing scaffold)
+#
+# Constraints: bash 3.2 (stock macOS), jq optional, no GNU-only tooling.
+
+set -euo pipefail
+
+# --- Size budget (RFC-011) -------------------------------------------------
+# Memory competes with the task description for context. These are advisory
+# thresholds, never enforced by truncation.
+SOFT_LIMIT_BYTES=8192
+HARD_LIMIT_BYTES=16384
+
+# --- Locate the repository root --------------------------------------------
+ROOT_PATH=""
+OPERATION=""
+AGENT_ID=""
+FORMAT="table"
+SHOW_MODE="full"
+ADD_SESSION=false
+ADD_TASKS=""
+ADD_SUCCEEDED=""
+
+usage() {
+  sed -n '2,24p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --init)
+    OPERATION="init"
+    shift
+    ;;
+  --path)
+    OPERATION="path"
+    shift
+    ;;
+  --show)
+    OPERATION="show"
+    shift
+    ;;
+  --list)
+    OPERATION="list"
+    shift
+    ;;
+  --update-metrics)
+    OPERATION="update-metrics"
+    shift
+    ;;
+  --reset-metrics)
+    OPERATION="reset-metrics"
+    shift
+    ;;
+  --check)
+    OPERATION="check"
+    shift
+    ;;
+  --agent)
+    [[ $# -ge 2 ]] || {
+      echo "Error: --agent requires a value" >&2
+      exit 1
+    }
+    AGENT_ID="$2"
+    shift 2
+    ;;
+  --root)
+    [[ $# -ge 2 ]] || {
+      echo "Error: --root requires a value" >&2
+      exit 1
+    }
+    ROOT_PATH="$2"
+    shift 2
+    ;;
+  --format)
+    [[ $# -ge 2 ]] || {
+      echo "Error: --format requires a value" >&2
+      exit 1
+    }
+    FORMAT="$2"
+    shift 2
+    ;;
+  --body-only)
+    SHOW_MODE="body"
+    shift
+    ;;
+  --frontmatter-only)
+    SHOW_MODE="frontmatter"
+    shift
+    ;;
+  --session)
+    ADD_SESSION=true
+    shift
+    ;;
+  --tasks)
+    [[ $# -ge 2 ]] || {
+      echo "Error: --tasks requires a value" >&2
+      exit 1
+    }
+    ADD_TASKS="$2"
+    shift 2
+    ;;
+  --succeeded)
+    [[ $# -ge 2 ]] || {
+      echo "Error: --succeeded requires a value" >&2
+      exit 1
+    }
+    ADD_SUCCEEDED="$2"
+    shift 2
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "Error: unknown argument '$1'" >&2
+    usage >&2
+    exit 1
+    ;;
+  esac
+done
+
+if [[ -z "$ROOT_PATH" ]]; then
+  ROOT_PATH="$(git rev-parse --show-toplevel 2> /dev/null || pwd)"
+fi
+
+AGENTS_DIR="${ROOT_PATH}/.agents"
+REGISTRY="${AGENTS_DIR}/registry.json"
+MEMORY_DIR="${AGENTS_DIR}/memory"
+AGENT_MEMORY_DIR="${MEMORY_DIR}/agents"
+RETRO_DIR="${AGENTS_DIR}/retrospectives"
+
+HAS_JQ=false
+if command -v jq &> /dev/null; then
+  HAS_JQ=true
+fi
+
+TODAY="$(date -u +%Y-%m-%d)"
+
+# --- Frontmatter helpers ---------------------------------------------------
+# Read a single frontmatter field. Prints the value, or nothing if absent.
+fm_get() {
+  local file="$1" key="$2"
+  [[ -f "$file" ]] || return 0
+  awk -v k="$key" '
+    NR == 1 && /^---[[:space:]]*$/ { infm = 1; next }
+    infm && /^---[[:space:]]*$/ { exit }
+    infm {
+      idx = index($0, ":")
+      if (idx > 0) {
+        f = substr($0, 1, idx - 1)
+        v = substr($0, idx + 1)
+        gsub(/^[ \t]+|[ \t]+$/, "", f)
+        gsub(/^[ \t]+|[ \t]+$/, "", v)
+        gsub(/^"|"$/, "", v)
+        if (f == k) { print v; exit }
+      }
+    }
+  ' "$file"
+}
+
+# Print everything after the closing frontmatter delimiter.
+fm_body() {
+  local file="$1"
+  [[ -f "$file" ]] || return 0
+  if [[ "$(head -1 "$file")" != "---" ]]; then
+    cat "$file"
+    return 0
+  fi
+  awk '
+    NR == 1 { next }
+    !done && /^---[[:space:]]*$/ { done = 1; next }
+    done { print }
+  ' "$file"
+}
+
+# Print the frontmatter block including delimiters.
+fm_header() {
+  local file="$1"
+  [[ -f "$file" ]] || return 0
+  awk '
+    NR == 1 && /^---[[:space:]]*$/ { print; infm = 1; next }
+    infm { print }
+    infm && /^---[[:space:]]*$/ { exit }
+  ' "$file"
+}
+
+agent_memory_path() {
+  echo "${AGENT_MEMORY_DIR}/$1.md"
+}
+
+# Ids of every agent the registry marks memory:true.
+registry_agent_ids() {
+  [[ -f "$REGISTRY" ]] || return 0
+  if $HAS_JQ; then
+    jq -r '.agents[] | select(.memory == true) | .id' "$REGISTRY"
+  else
+    # Pair each id with the memory flag that follows it on the same object line-run.
+    awk '
+      /"id"[[:space:]]*:/ {
+        line = $0
+        sub(/.*"id"[[:space:]]*:[[:space:]]*"/, "", line)
+        sub(/".*/, "", line)
+        current = line
+      }
+      /"memory"[[:space:]]*:[[:space:]]*true/ { if (current != "") { print current; current = "" } }
+    ' "$REGISTRY"
+  fi
+}
+
+require_scaffold() {
+  if [[ ! -d "$AGENTS_DIR" ]]; then
+    echo "Error: .agents/ not found at ${AGENTS_DIR}" >&2
+    echo "Run: agent-memory.sh --init" >&2
+    exit 1
+  fi
+}
+
+file_size_bytes() {
+  # wc -c is portable; awk strips the leading whitespace BSD wc emits.
+  wc -c < "$1" | awk '{print $1}'
+}
+
+# --- Operation: init -------------------------------------------------------
+if [[ "$OPERATION" == "init" ]]; then
+  mkdir -p "$AGENT_MEMORY_DIR" "$RETRO_DIR"
+
+  if [[ ! -f "$REGISTRY" ]]; then
+    cat > "$REGISTRY" << 'EOF'
+{
+  "version": 1,
+  "agents": [
+    {
+      "id": "impl-worker",
+      "plugin": "principled-implementation",
+      "role": "worker",
+      "memory": true,
+      "rationale": "Primary beneficiary — implementation patterns and codebase knowledge"
+    },
+    {
+      "id": "issue-ingester",
+      "plugin": "principled-github",
+      "role": "triage",
+      "memory": true,
+      "rationale": "Triage and classification patterns accumulate"
+    },
+    {
+      "id": "pr-reviewer",
+      "plugin": "principled-quality",
+      "role": "reviewer",
+      "memory": true,
+      "rationale": "Learns recurring review themes"
+    },
+    {
+      "id": "module-auditor",
+      "plugin": "principled-docs",
+      "role": "auditor",
+      "memory": false,
+      "rationale": "Runs a deterministic script; nothing to learn"
+    },
+    {
+      "id": "decision-auditor",
+      "plugin": "principled-docs",
+      "role": "auditor",
+      "memory": false,
+      "rationale": "Checks supersession chains deterministically"
+    },
+    {
+      "id": "boundary-checker",
+      "plugin": "principled-architecture",
+      "role": "auditor",
+      "memory": false,
+      "rationale": "Scans imports against fixed rules"
+    }
+  ]
+}
+EOF
+    echo "Created ${REGISTRY}"
+  else
+    echo "Registry already exists: ${REGISTRY}"
+  fi
+
+  if [[ ! -f "${MEMORY_DIR}/global.md" ]]; then
+    cat > "${MEMORY_DIR}/global.md" << EOF
+---
+scope: global
+last_updated: ${TODAY}
+---
+
+# Global Agent Memory
+
+Knowledge that applies to every agent in this repository. Keep this curated: every
+byte here is injected into every agent's context.
+
+## Conventions
+
+<!-- Add repository-wide facts agents should not have to rediscover. -->
+EOF
+    echo "Created ${MEMORY_DIR}/global.md"
+  fi
+
+  # Seed a memory file for each registered agent that carries memory.
+  created=0
+  for id in $(registry_agent_ids); do
+    mem_file="$(agent_memory_path "$id")"
+    if [[ ! -f "$mem_file" ]]; then
+      cat > "$mem_file" << EOF
+---
+agent_id: "${id}"
+role: worker
+last_updated: ${TODAY}
+session_count: 0
+total_tasks: 0
+success_rate: 0.0
+specializations: []
+---
+
+# ${id} — Accumulated Knowledge
+
+## Known Patterns
+
+<!-- Durable facts about this codebase that this agent should not relearn. -->
+
+## Pitfalls
+
+<!-- Mistakes made before, and what to do instead. -->
+EOF
+      created=$((created + 1))
+    fi
+  done
+  echo "Seeded ${created} agent memory file(s) in ${AGENT_MEMORY_DIR}"
+  echo "Initialized .agents/ at ${AGENTS_DIR}"
+  exit 0
+fi
+
+# --- Operation: path -------------------------------------------------------
+if [[ "$OPERATION" == "path" ]]; then
+  [[ -n "$AGENT_ID" ]] || {
+    echo "Error: --path requires --agent" >&2
+    exit 1
+  }
+  agent_memory_path "$AGENT_ID"
+  exit 0
+fi
+
+# --- Operation: show -------------------------------------------------------
+if [[ "$OPERATION" == "show" ]]; then
+  require_scaffold
+  [[ -n "$AGENT_ID" ]] || {
+    echo "Error: --show requires --agent" >&2
+    exit 1
+  }
+  mem_file="$(agent_memory_path "$AGENT_ID")"
+  if [[ ! -f "$mem_file" ]]; then
+    echo "Error: no memory file for agent '${AGENT_ID}' at ${mem_file}" >&2
+    exit 1
+  fi
+  case "$SHOW_MODE" in
+  body) fm_body "$mem_file" ;;
+  frontmatter) fm_header "$mem_file" ;;
+  *) cat "$mem_file" ;;
+  esac
+  exit 0
+fi
+
+# --- Operation: list -------------------------------------------------------
+if [[ "$OPERATION" == "list" ]]; then
+  require_scaffold
+  case "$FORMAT" in
+  table | json) ;;
+  *)
+    echo "Error: unknown format '${FORMAT}' (expected table or json)" >&2
+    exit 1
+    ;;
+  esac
+
+  if [[ "$FORMAT" == "json" ]]; then
+    printf '{\n  "agents": [\n'
+    first=true
+    for id in $(registry_agent_ids); do
+      mem_file="$(agent_memory_path "$id")"
+      if [[ -f "$mem_file" ]]; then
+        size="$(file_size_bytes "$mem_file")"
+        sessions="$(fm_get "$mem_file" session_count)"
+        tasks="$(fm_get "$mem_file" total_tasks)"
+        rate="$(fm_get "$mem_file" success_rate)"
+        updated="$(fm_get "$mem_file" last_updated)"
+      else
+        size=0
+        sessions=0
+        tasks=0
+        rate=0.0
+        updated=""
+      fi
+      $first || printf ',\n'
+      first=false
+      printf '    {"id": "%s", "bytes": %s, "session_count": %s, "total_tasks": %s, "success_rate": %s, "last_updated": "%s"}' \
+        "$id" "${size:-0}" "${sessions:-0}" "${tasks:-0}" "${rate:-0.0}" "${updated:-}"
+    done
+    printf '\n  ]\n}\n'
+  else
+    printf '%-18s %8s %9s %7s %9s  %s\n' "AGENT" "BYTES" "SESSIONS" "TASKS" "SUCCESS" "UPDATED"
+    for id in $(registry_agent_ids); do
+      mem_file="$(agent_memory_path "$id")"
+      if [[ -f "$mem_file" ]]; then
+        printf '%-18s %8s %9s %7s %9s  %s\n' \
+          "$id" \
+          "$(file_size_bytes "$mem_file")" \
+          "$(fm_get "$mem_file" session_count)" \
+          "$(fm_get "$mem_file" total_tasks)" \
+          "$(fm_get "$mem_file" success_rate)" \
+          "$(fm_get "$mem_file" last_updated)"
+      else
+        printf '%-18s %8s %9s %7s %9s  %s\n' "$id" "-" "-" "-" "-" "(no memory file)"
+      fi
+    done
+  fi
+  exit 0
+fi
+
+# --- Rewrite frontmatter metrics, preserving the body ----------------------
+# Only the metric fields are script-owned (ADR-020); everything else in the
+# frontmatter is passed through untouched.
+write_metrics() {
+  local file="$1" sessions="$2" tasks="$3" rate="$4"
+  local tmp
+  tmp="$(mktemp)"
+
+  awk -v sessions="$sessions" -v tasks="$tasks" -v rate="$rate" -v today="$TODAY" '
+    NR == 1 && /^---[[:space:]]*$/ { print; infm = 1; next }
+    infm && /^---[[:space:]]*$/ {
+      infm = 0
+      if (!seen_sessions) print "session_count: " sessions
+      if (!seen_tasks) print "total_tasks: " tasks
+      if (!seen_rate) print "success_rate: " rate
+      if (!seen_updated) print "last_updated: " today
+      print
+      next
+    }
+    infm {
+      if ($0 ~ /^session_count:/) { print "session_count: " sessions; seen_sessions = 1; next }
+      if ($0 ~ /^total_tasks:/)   { print "total_tasks: " tasks;      seen_tasks = 1; next }
+      if ($0 ~ /^success_rate:/)  { print "success_rate: " rate;      seen_rate = 1; next }
+      if ($0 ~ /^last_updated:/)  { print "last_updated: " today;     seen_updated = 1; next }
+      print
+      next
+    }
+    { print }
+  ' "$file" > "$tmp"
+
+  mv "$tmp" "$file"
+}
+
+# --- Operation: update-metrics ---------------------------------------------
+if [[ "$OPERATION" == "update-metrics" ]]; then
+  require_scaffold
+  [[ -n "$AGENT_ID" ]] || {
+    echo "Error: --update-metrics requires --agent" >&2
+    exit 1
+  }
+  mem_file="$(agent_memory_path "$AGENT_ID")"
+  if [[ ! -f "$mem_file" ]]; then
+    echo "Error: no memory file for agent '${AGENT_ID}'" >&2
+    exit 1
+  fi
+
+  for value in "$ADD_TASKS" "$ADD_SUCCEEDED"; do
+    if [[ -n "$value" && ! "$value" =~ ^[0-9]+$ ]]; then
+      echo "Error: --tasks and --succeeded require non-negative integers (got '${value}')" >&2
+      exit 1
+    fi
+  done
+
+  cur_sessions="$(fm_get "$mem_file" session_count)"
+  cur_sessions="${cur_sessions:-0}"
+  cur_tasks="$(fm_get "$mem_file" total_tasks)"
+  cur_tasks="${cur_tasks:-0}"
+  cur_rate="$(fm_get "$mem_file" success_rate)"
+  cur_rate="${cur_rate:-0.0}"
+
+  new_sessions="$cur_sessions"
+  $ADD_SESSION && new_sessions=$((cur_sessions + 1))
+
+  added_tasks="${ADD_TASKS:-0}"
+  added_ok="${ADD_SUCCEEDED:-0}"
+  if [[ "$added_ok" -gt "$added_tasks" ]]; then
+    echo "Error: --succeeded (${added_ok}) cannot exceed --tasks (${added_tasks})" >&2
+    exit 1
+  fi
+
+  new_tasks=$((cur_tasks + added_tasks))
+
+  # Recompute the rate from prior successes plus new ones. Integer bash cannot
+  # do this, so awk carries the float.
+  new_rate="$(awk -v ct="$cur_tasks" -v cr="$cur_rate" -v at="$added_tasks" -v ao="$added_ok" '
+    BEGIN {
+      prior_ok = ct * cr
+      total = ct + at
+      if (total <= 0) { printf "0.0"; exit }
+      printf "%.2f", (prior_ok + ao) / total
+    }')"
+
+  write_metrics "$mem_file" "$new_sessions" "$new_tasks" "$new_rate"
+  echo "Updated ${AGENT_ID}: sessions=${new_sessions} tasks=${new_tasks} success_rate=${new_rate}"
+  exit 0
+fi
+
+# --- Operation: reset-metrics ----------------------------------------------
+# Fork support (RFC-011): knowledge transfers, performance history does not.
+if [[ "$OPERATION" == "reset-metrics" ]]; then
+  require_scaffold
+  if [[ -n "$AGENT_ID" ]]; then
+    targets="$AGENT_ID"
+  else
+    targets="$(registry_agent_ids)"
+  fi
+
+  reset_count=0
+  for id in $targets; do
+    mem_file="$(agent_memory_path "$id")"
+    [[ -f "$mem_file" ]] || continue
+    write_metrics "$mem_file" 0 0 "0.0"
+    reset_count=$((reset_count + 1))
+  done
+  echo "Reset metrics for ${reset_count} agent(s). Knowledge bodies left intact."
+  exit 0
+fi
+
+# --- Operation: check ------------------------------------------------------
+# Validates structure and reports against the size budget. Reports problems on
+# stdout and exits 1 only on genuine structural errors, never on size.
+if [[ "$OPERATION" == "check" ]]; then
+  require_scaffold
+  if [[ -n "$AGENT_ID" ]]; then
+    targets="$AGENT_ID"
+  else
+    targets="$(registry_agent_ids)"
+  fi
+
+  errors=0
+  for id in $targets; do
+    mem_file="$(agent_memory_path "$id")"
+    if [[ ! -f "$mem_file" ]]; then
+      echo "ERROR: ${id}: registry says memory=true but no file at ${mem_file}"
+      errors=$((errors + 1))
+      continue
+    fi
+
+    if [[ "$(head -1 "$mem_file")" != "---" ]]; then
+      echo "ERROR: ${id}: missing YAML frontmatter"
+      errors=$((errors + 1))
+      continue
+    fi
+
+    declared="$(fm_get "$mem_file" agent_id)"
+    if [[ "$declared" != "$id" ]]; then
+      echo "ERROR: ${id}: frontmatter agent_id is '${declared}', expected '${id}'"
+      errors=$((errors + 1))
+    fi
+
+    size="$(file_size_bytes "$mem_file")"
+    if [[ "$size" -gt "$HARD_LIMIT_BYTES" ]]; then
+      echo "WARN: ${id}: memory is ${size} bytes, over the ${HARD_LIMIT_BYTES} byte budget."
+      echo "      Every byte is injected at spawn. Synthesize it down; do not truncate."
+    elif [[ "$size" -gt "$SOFT_LIMIT_BYTES" ]]; then
+      echo "WARN: ${id}: memory is ${size} bytes, over the ${SOFT_LIMIT_BYTES} byte soft budget."
+      echo "      Consider synthesizing accumulated notes into fewer, denser statements."
+    else
+      echo "OK: ${id}: ${size} bytes"
+    fi
+  done
+
+  if [[ "$errors" -gt 0 ]]; then
+    echo "${errors} structural error(s) found." >&2
+    exit 1
+  fi
+  exit 0
+fi
+
+echo "Error: no operation specified" >&2
+usage >&2
+exit 1

--- a/plugins/principled-agent/skills/agent-init/SKILL.md
+++ b/plugins/principled-agent/skills/agent-init/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: agent-init
+description: >
+  Scaffold the .agents/ directory in a repository: identity registry, global and
+  per-agent memory files, and the retrospectives directory. Idempotent — safe to
+  run on a repository that is already initialized. Use when setting up agent
+  memory for the first time.
+allowed-tools: Read, Write, Bash(bash plugins/*), Bash(bash scripts/*), Bash(git add *), Bash(git commit *), Bash(mkdir *), Bash(ls *)
+user-invocable: true
+---
+
+# Agent Init — Scaffold `.agents/`
+
+Create the agent identity and memory structure at the repository root.
+
+## Command
+
+```
+/agent-init [--commit]
+```
+
+## Arguments
+
+| Argument   | Required | Description                           |
+| ---------- | -------- | ------------------------------------- |
+| `--commit` | No       | Commit the scaffold after creating it |
+
+## What gets created
+
+```
+.agents/
+  registry.json          # Agent identity registry — who exists, who carries memory
+  memory/
+    global.md            # Knowledge applying to every agent
+    agents/
+      impl-worker.md     # One file per memory-bearing agent
+      issue-ingester.md
+      pr-reviewer.md
+  retrospectives/        # Post-execution retrospectives
+```
+
+`.agents/` is **committed to git**, unlike `.claude/agent-memory/` which is gitignored.
+It is shared team knowledge reviewable in pull requests, not session-local scratch.
+
+## Workflow
+
+1. **Scaffold.** Idempotent — existing files are left untouched:
+
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/lib/agent-memory.sh" --init
+   ```
+
+2. **Verify.** Confirm the registry parses and every `memory: true` agent has a file:
+
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/lib/agent-memory.sh" --check
+   ```
+
+3. **Seed global memory (optional but recommended).** The scaffold leaves
+   `.agents/memory/global.md` with an empty Conventions section. Fill it with
+   repository-wide facts every agent should not have to rediscover — build commands,
+   language and runtime constraints, layout conventions.
+
+   Keep it short. Global memory is injected for _every_ agent, so it is the most
+   expensive place to put anything.
+
+4. **Commit** when `--commit` is passed:
+
+   ```bash
+   git add .agents/
+   git commit -m "chore: scaffold agent memory (.agents/)"
+   ```
+
+5. **Report.** Show the created tree, which agents carry memory and which do not (with
+   the registry's rationale), and point to `/agent-memory <id>` for viewing and editing.
+
+## Notes
+
+- Safe to re-run. Existing memory files are never overwritten.
+- Adding a new memory-bearing agent means adding it to `registry.json` with
+  `"memory": true` and re-running `/agent-init` to seed its file.
+
+## Scripts
+
+- `${CLAUDE_PLUGIN_ROOT}/lib/agent-memory.sh` — memory and registry interface (ADR-018)

--- a/plugins/principled-agent/skills/agent-memory/SKILL.md
+++ b/plugins/principled-agent/skills/agent-memory/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: agent-memory
+description: >
+  Inspect and curate agent memory: show what an agent has learned, list memory
+  sizes against the context budget, record a durable learning, and reset
+  performance metrics after a fork. Use when reviewing what agents know or when
+  a memory file has grown past its budget.
+allowed-tools: Read, Write, Edit, Bash(bash plugins/*), Bash(bash scripts/*), Bash(git add *), Bash(git commit *), Bash(ls *)
+user-invocable: true
+---
+
+# Agent Memory — Inspect and Curate
+
+View, add to, and prune what agents have learned.
+
+## Command
+
+```
+/agent-memory [<agent-id>] [--list] [--learn "<fact>"] [--reset-metrics] [--check]
+```
+
+## Arguments
+
+| Argument           | Required | Description                                              |
+| ------------------ | -------- | -------------------------------------------------------- |
+| `<agent-id>`       | No       | Agent to inspect (e.g. `impl-worker`). Omit to list all  |
+| `--list`           | No       | Table of every agent's memory size and metrics           |
+| `--learn "<fact>"` | No       | Append a durable fact to the agent's Known Patterns      |
+| `--reset-metrics`  | No       | Zero performance counters, leaving knowledge intact      |
+| `--check`          | No       | Validate structure and report against the context budget |
+
+## Workflow
+
+### Showing memory
+
+With an agent id and no other flag, display the file:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/lib/agent-memory.sh" --show --agent "<agent-id>"
+```
+
+Report the metrics from frontmatter, the size against the budget, and the knowledge
+body. If the file is over 8 KB, say so and offer to synthesize.
+
+### Listing
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/lib/agent-memory.sh" --list
+```
+
+Flag any agent over the soft budget as a synthesis candidate.
+
+### Recording a learning
+
+With `--learn`, append to the agent's `## Known Patterns` section using Edit. Before
+writing, apply the standard from `agent-strategy`:
+
+- Is it **durable** — still true after every current task closes?
+- Is it **certain**? Memory is asserted to future agents as fact. Record a hedge as a
+  hedge, or not at all.
+- Is it **not already there**? Prefer sharpening an existing line over adding a near
+  duplicate; duplicates are how files reach the budget.
+
+Then update metrics if a session is being recorded:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/lib/agent-memory.sh" --update-metrics \
+  --agent "<agent-id>" --session --tasks <n> --succeeded <n>
+```
+
+### Synthesizing an oversized file
+
+When `--check` reports a file over budget, **rewrite rather than truncate**. Read the
+whole body, merge overlapping notes into fewer denser statements, drop anything no
+longer true, and write it back with Edit. Preserve the frontmatter exactly — metrics are
+script-owned.
+
+Never delete the tail of the file to fit. Losing knowledge invisibly is the failure mode
+the budget exists to prevent, not a way to satisfy it.
+
+### Resetting metrics after a fork
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/lib/agent-memory.sh" --reset-metrics [--agent "<agent-id>"]
+```
+
+Knowledge transfers across a fork because it describes code the fork still has.
+Performance history does not, because it was earned against a different repository.
+
+## Reporting
+
+State plainly what changed, what the file now weighs against the budget, and — for a
+`--learn` — the exact line added, so it can be reviewed or reverted.
+
+## Scripts
+
+- `${CLAUDE_PLUGIN_ROOT}/lib/agent-memory.sh` — memory and registry interface (ADR-018)

--- a/plugins/principled-agent/skills/agent-retro/SKILL.md
+++ b/plugins/principled-agent/skills/agent-retro/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: agent-retro
+description: >
+  Write a post-execution retrospective after an orchestration run, and promote
+  the durable findings into agent memory. Use after /orchestrate completes a
+  plan or phase, or after a run that failed in an instructive way.
+allowed-tools: Read, Write, Edit, Bash(bash plugins/*), Bash(bash scripts/*), Bash(git add *), Bash(git commit *), Bash(ls *), Bash(git log *)
+user-invocable: true
+---
+
+# Agent Retro — Post-Execution Retrospective
+
+Record what a run taught, and promote the durable parts into memory.
+
+## Command
+
+```
+/agent-retro [<plan-path>] [--promote]
+```
+
+## Arguments
+
+| Argument      | Required | Description                                                  |
+| ------------- | -------- | ------------------------------------------------------------ |
+| `<plan-path>` | No       | Plan the run executed. Inferred from the manifest if omitted |
+| `--promote`   | No       | Also write durable findings into agent memory                |
+
+## Why retrospectives are separate from memory
+
+A retrospective is a **dated record of one run**: what happened, what failed, how long
+it took. Memory is **durable knowledge**, undated and asserted as currently true.
+
+Most of a retrospective should never reach memory. "task-2b failed twice on the test
+suite" is a fact about one run. "This suite needs `--runInBand` or the database fixtures
+collide" is a fact about the codebase — that one belongs in memory.
+
+Keeping them separate is what stops memory degrading into a log.
+
+## Workflow
+
+1. **Gather the run.** Read `.impl/manifest.json` directly with Read — task outcomes,
+   retry counts, and the `checkpoint.orchestrator_summary` if one was written.
+
+   principled-agent does not depend on principled-implementation: plugins install
+   independently and cannot reference each other's `${CLAUDE_PLUGIN_ROOT}` (ADR-018).
+   Read the manifest as a file, and fall back to `git log` over the run's branches when
+   there is no manifest at all.
+
+2. **Write the retrospective** to `.agents/retrospectives/YYYY-MM-DD-plan-NNN.md`:
+
+   ```markdown
+   ---
+   date: 2026-07-28
+   plan: "008"
+   agent: impl-worker
+   tasks_total: 7
+   tasks_merged: 6
+   tasks_failed: 1
+   ---
+
+   # Retrospective — Plan-008
+
+   ## What happened
+
+   ## What worked
+
+   ## What failed, and why
+
+   ## Durable learnings
+
+   <!-- Only facts that will still be true next month. These are memory candidates. -->
+   ```
+
+   Be specific and unflattering. A retrospective that records only successes teaches
+   nothing and costs a file.
+
+3. **Promote, when `--promote` is passed.** For each item under Durable learnings, apply
+   the `agent-strategy` standard — durable, certain, not already present — then append
+   the survivors to the relevant agent's `## Known Patterns` via `/agent-memory`.
+
+   Promote conservatively. A wrong learning is injected into every future spawn and is
+   harder to notice than a wrong retrospective, because nobody re-reads memory to check.
+
+4. **Update metrics** from the run's actual outcome:
+
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/lib/agent-memory.sh" --update-metrics \
+     --agent impl-worker --session --tasks <total> --succeeded <merged>
+   ```
+
+5. **Commit.** Retrospectives and memory changes are reviewable artifacts:
+
+   ```bash
+   git add .agents/
+   git commit -m "retro: plan-NNN execution retrospective"
+   ```
+
+## Reporting
+
+Summarize the run, list what was promoted to memory and what was deliberately left in
+the retrospective, and state the agent's updated metrics.
+
+## Scripts
+
+- `${CLAUDE_PLUGIN_ROOT}/lib/agent-memory.sh` — memory and registry interface (ADR-018)

--- a/plugins/principled-agent/skills/agent-strategy/SKILL.md
+++ b/plugins/principled-agent/skills/agent-strategy/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: agent-strategy
+description: >
+  Background knowledge on agent identity and memory: what belongs in memory,
+  what does not, how memory differs from the task graph, and how the context
+  budget is governed. Loaded as context for the other principled-agent skills.
+  Not user-invocable.
+user-invocable: false
+---
+
+# Agent Strategy — Identity and Memory
+
+Background knowledge for working with `.agents/`. This skill is not invoked directly.
+
+## The distinction that governs everything
+
+**Memory is state about the worker. The task graph is state about the work.**
+
+principled-tasks (ADR-017) owns the backlog: what needs doing, what blocks what, who is
+assigned. principled-agent owns what an agent has _learned_. When deciding where
+something belongs, ask whether it would still be true after every open task closed. If
+yes, it is memory.
+
+## What belongs in memory
+
+Durable facts about the codebase that an agent would otherwise rediscover every session:
+
+- Conventions that are not obvious from any single file (`lib/` layout, ADR-018)
+- Environment constraints (macOS ships bash 3.2 — no `declare -A`, no `grep -P`)
+- Pitfalls encountered and the correct approach instead
+- Where things live, when the location is surprising
+
+## What does not belong in memory
+
+- **Task state.** That is the manifest's job (ADR-008) or the task graph's (ADR-017).
+- **Anything session-scoped.** If it stops being true when the session ends, it is not
+  memory.
+- **Secrets.** `.agents/` is committed and pushed like any other directory.
+- **Speculation.** Memory is asserted to future agents as fact. An uncertain conclusion
+  recorded confidently becomes a bug that recurs on every spawn.
+
+## Which agents carry memory
+
+Only agents spawned repeatedly for substantively similar work accumulate anything
+useful. Agents that run a deterministic script learn nothing by definition.
+
+| Agent              | Memory? | Rationale                                    |
+| ------------------ | :-----: | -------------------------------------------- |
+| `impl-worker`      |   Yes   | Implementation patterns, codebase knowledge  |
+| `issue-ingester`   |   Yes   | Triage and classification patterns           |
+| `pr-reviewer`      |   Yes   | Recurring review themes                      |
+| `module-auditor`   |   No    | Runs a deterministic script                  |
+| `decision-auditor` |   No    | Checks supersession chains deterministically |
+| `boundary-checker` |   No    | Scans imports against fixed rules            |
+
+This is recorded in `.agents/registry.json` as the `memory` flag.
+
+## Format
+
+Markdown with YAML frontmatter, one file per agent (ADR-020). Frontmatter carries
+queryable metadata; the body carries prose the model reads directly.
+
+Memory is **revised, not appended**. A learning that turns out to be wrong is edited
+out, and git history records that it was ever believed. This is the property that
+distinguishes memory from the event log in ADR-017, where past entries are immutable by
+design — a wrong learned pattern that cannot be deleted compounds on every spawn.
+
+Metric fields (`session_count`, `total_tasks`, `success_rate`, `last_updated`) are
+script-owned. Use `agent-memory.sh --update-metrics`; do not hand-edit them.
+
+## The context budget
+
+Every byte of memory is injected at spawn and competes with the task description for
+the model's attention. The budget is therefore stated in bytes:
+
+| Size         | Behaviour                                    |
+| ------------ | -------------------------------------------- |
+| under 8 KB   | silent                                       |
+| 8 KB – 16 KB | advisory warning, synthesis suggested        |
+| over 16 KB   | louder warning; injection still delivers all |
+
+**Injection is never truncated.** A silently halved memory file gives an agent a
+confidently incomplete picture, and the loss is invisible to it. Oversized memory is
+reported, never quietly trimmed.
+
+The cure for a bloated file is synthesis — rewriting many accumulated notes into fewer,
+denser statements. That requires judgment, so it is a human act today. RFC-013's
+`/improve` will automate it.
+
+## Forks
+
+`.agents/` is committed, so a fork inherits everything. Knowledge should transfer — it
+describes code the fork still has. Performance metrics should not: they describe a
+record against the parent repository's codebase and CI.
+
+Fork detection is unreliable (a fork, a template instantiation, and a clone are
+indistinguishable from inside the repository), so resetting is an explicit command:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/lib/agent-memory.sh" --reset-metrics
+```
+
+## Scripts
+
+- `${CLAUDE_PLUGIN_ROOT}/lib/agent-memory.sh` — memory and registry interface (ADR-018)

--- a/plugins/principled-implementation/lib/task-manifest.sh
+++ b/plugins/principled-implementation/lib/task-manifest.sh
@@ -13,6 +13,18 @@
 #   task-manifest.sh --phase-status --phase <N>
 #   task-manifest.sh --summary
 #
+# Checkpoint and acceptance criteria (ADR-021):
+#   task-manifest.sh --set-checkpoint --summary-text "<text>" [--session-id <id>] \
+#                    [--agent-id <id>] [--phase <N>] [--pending-decisions "<a|b>"]
+#   task-manifest.sh --get-checkpoint
+#   task-manifest.sh --clear-checkpoint
+#   task-manifest.sh --set-criteria --task-id <id> --criteria "<desc1|desc2|...>"
+#   task-manifest.sh --verify-criterion --task-id <id> --criterion-index <N>
+#   task-manifest.sh --list-criteria --task-id <id>
+#
+# The checkpoint is advisory context for a resuming session. Task state remains
+# authoritative; where the two disagree, task state wins (ADR-021).
+#
 # Manifest location: .impl/manifest.json
 #
 # Valid statuses:
@@ -41,6 +53,13 @@ BRANCH=""
 CHECK_RESULTS=""
 ERROR_MSG=""
 FORCE=false
+SESSION_ID=""
+AGENT_ID=""
+SUMMARY_TEXT=""
+PENDING_DECISIONS=""
+ACTIVE_WORKTREES=""
+CRITERIA=""
+CRITERION_INDEX=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -75,6 +94,58 @@ while [[ $# -gt 0 ]]; do
   --summary)
     OPERATION="summary"
     shift
+    ;;
+  --set-checkpoint)
+    OPERATION="set-checkpoint"
+    shift
+    ;;
+  --get-checkpoint)
+    OPERATION="get-checkpoint"
+    shift
+    ;;
+  --clear-checkpoint)
+    OPERATION="clear-checkpoint"
+    shift
+    ;;
+  --set-criteria)
+    OPERATION="set-criteria"
+    shift
+    ;;
+  --verify-criterion)
+    OPERATION="verify-criterion"
+    shift
+    ;;
+  --list-criteria)
+    OPERATION="list-criteria"
+    shift
+    ;;
+  --session-id)
+    SESSION_ID="$2"
+    shift 2
+    ;;
+  --agent-id)
+    AGENT_ID="$2"
+    shift 2
+    ;;
+  --summary-text)
+    SUMMARY_TEXT="$2"
+    shift 2
+    ;;
+  --pending-decisions)
+    PENDING_DECISIONS="$2"
+    shift 2
+    ;;
+  --active-worktrees)
+    ACTIVE_WORKTREES="$2"
+    shift 2
+    ;;
+  --criteria)
+    CRITERIA="$2"
+    shift 2
+    ;;
+  --criterion-index)
+    CRITERION_INDEX="$2"
+    shift 2
     ;;
   --plan-path)
     PLAN_PATH="$2"
@@ -278,17 +349,43 @@ if [[ "$OPERATION" == "add-task" ]]; then
     # This is a simplified approach for the known schema
     TASK_JSON="    {\"id\": \"${TASK_ID}\", \"phase\": ${PHASE}, \"description\": \"${DESCRIPTION}\", \"bounded_contexts\": [\"${BOUNDED_CONTEXTS}\"], \"status\": \"pending\", \"branch\": null, \"check_results\": null, \"error\": null, \"retries\": 0, \"created_at\": \"${NOW}\", \"updated_at\": \"${NOW}\"}"
 
-    # Find the tasks array closing bracket and insert before it
+    # Find the tasks array closing bracket and insert before it.
+    # awk, not `sed -i`: BSD sed reads the argument after -i as a backup suffix,
+    # so `sed -i <expr> <file>` silently misparses on stock macOS.
     TMP="$(mktemp)"
     TASKS_EMPTY="$(grep -c '"tasks": \[\]' "$MANIFEST" || true)"
     if [[ "$TASKS_EMPTY" -gt 0 ]]; then
-      sed "s|\"tasks\": \[\]|\"tasks\": [\n${TASK_JSON}\n  ]|" "$MANIFEST" > "$TMP" && mv "$TMP" "$MANIFEST"
+      awk -v task="$TASK_JSON" '
+        /"tasks"[[:space:]]*:[[:space:]]*\[\]/ {
+          sub(/"tasks"[[:space:]]*:[[:space:]]*\[\]/, "\"tasks\": [")
+          print
+          print task
+          print "  ]"
+          next
+        }
+        { print }
+      ' "$MANIFEST" > "$TMP" && mv "$TMP" "$MANIFEST"
     else
-      # Insert before the last ] in the tasks array
-      sed -i "/\"tasks\":/,/\]/ { /\]/ i\\
-,\\
-${TASK_JSON}
-}" "$MANIFEST"
+      # Append inside the existing tasks array. Hold the previous line back so the
+      # last element can take a trailing comma before the new one is written.
+      awk -v task="$TASK_JSON" '
+        !intasks && /"tasks"[[:space:]]*:[[:space:]]*\[/ { intasks = 1; print; next }
+        intasks && /^[[:space:]]*\][[:space:]]*,?[[:space:]]*$/ {
+          if (prev != "") print prev ","
+          print task
+          print $0
+          intasks = 0
+          prev = ""
+          next
+        }
+        intasks {
+          if (prev != "") print prev
+          prev = $0
+          next
+        }
+        { print }
+        END { if (prev != "") print prev }
+      ' "$MANIFEST" > "$TMP" && mv "$TMP" "$MANIFEST"
     fi
   fi
 
@@ -374,16 +471,38 @@ if [[ "$OPERATION" == "update-status" ]]; then
       "(.tasks[] | select(.id == \$id)) |= ($UPDATE_EXPR)" \
       "$MANIFEST" > "$TMP" && mv "$TMP" "$MANIFEST"
   else
-    # Without jq: use sed to update the status field
+    # Without jq: rewrite the matching task's fields with awk.
+    # `sed -i` is unusable here — BSD sed treats the following argument as a
+    # backup suffix, so the same invocation behaves differently on macOS and
+    # Linux. awk with a temp file behaves identically on both.
     TMP="$(mktemp)"
-    sed "s|\"id\": \"${TASK_ID}\",|\"id\": \"${TASK_ID}\", \"__UPDATING__\": true,|" "$MANIFEST" > "$TMP"
-    sed -i "/__UPDATING__/,/}/ s|\"status\": \"[^\"]*\"|\"status\": \"${STATUS}\"|" "$TMP"
-    sed -i "/__UPDATING__/,/}/ s|\"updated_at\": \"[^\"]*\"|\"updated_at\": \"${NOW}\"|" "$TMP"
-    if [[ -n "$BRANCH" ]]; then
-      sed -i "/__UPDATING__/,/}/ s|\"branch\": [^,]*|\"branch\": \"${BRANCH}\"|" "$TMP"
-    fi
-    sed -i "s|\"__UPDATING__\": true, ||" "$TMP"
-    mv "$TMP" "$MANIFEST"
+    awk -v id="$TASK_ID" -v status="$STATUS" -v now="$NOW" -v branch="$BRANCH" '
+      # A task object may be one line (written without jq) or several (written
+      # with jq). Track whether the current object is the target either way.
+      {
+        line = $0
+
+        if (index(line, "\"id\": \"" id "\"") > 0) {
+          intask = 1
+        }
+
+        if (intask) {
+          gsub(/"status"[[:space:]]*:[[:space:]]*"[^"]*"/, "\"status\": \"" status "\"", line)
+          gsub(/"updated_at"[[:space:]]*:[[:space:]]*"[^"]*"/, "\"updated_at\": \"" now "\"", line)
+          if (branch != "") {
+            gsub(/"branch"[[:space:]]*:[[:space:]]*(null|"[^"]*")/, "\"branch\": \"" branch "\"", line)
+          }
+        }
+
+        # A single-line object opens and closes on the same line; a multi-line
+        # object ends at a closing brace. Either way, stop after the object ends.
+        if (intask && index(line, "}") > 0) {
+          intask = 0
+        }
+
+        print line
+      }
+    ' "$MANIFEST" > "$TMP" && mv "$TMP" "$MANIFEST"
   fi
 
   echo "Task $TASK_ID status updated to $STATUS"
@@ -462,6 +581,421 @@ if [[ "$OPERATION" == "summary" ]]; then
   else
     echo "plan_title=$(sed -n 's/.*"title"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$MANIFEST" | head -1)"
     echo "total_tasks=$(grep -c '"id":' "$MANIFEST" || echo "0")"
+  fi
+  exit 0
+fi
+
+# ===========================================================================
+# Checkpoint and acceptance criteria (ADR-021)
+#
+# Both are additive and optional. A manifest without them is valid, and every
+# consumer must tolerate their absence.
+# ===========================================================================
+
+# Escape a value for embedding in a JSON string literal.
+json_escape() {
+  printf '%s' "$1" | awk '
+    {
+      gsub(/\\/, "\\\\")
+      gsub(/"/, "\\\"")
+      gsub(/\t/, "\\t")
+      gsub(/\r/, "")
+      lines[NR] = $0
+    }
+    END {
+      out = ""
+      for (i = 1; i <= NR; i++) {
+        out = out (i > 1 ? "\\n" : "") lines[i]
+      }
+      printf "%s", out
+    }
+  '
+}
+
+# Remove a top-level key and its (possibly nested) value, then repair a
+# dangling comma if the removed key was last. Used only on the no-jq path.
+strip_top_level_key() {
+  local file="$1" key="$2" tmp
+  tmp="$(mktemp)"
+
+  awk -v key="$key" '
+    !inkey && $0 ~ ("^[[:space:]]*\"" key "\"[[:space:]]*:") {
+      inkey = 1
+      opens = gsub(/[{[]/, "&")
+      closes = gsub(/[}\]]/, "&")
+      depth = opens - closes
+      if (depth <= 0) inkey = 0
+      next
+    }
+    inkey {
+      opens = gsub(/[{[]/, "&")
+      closes = gsub(/[}\]]/, "&")
+      depth += opens - closes
+      if (depth <= 0) inkey = 0
+      next
+    }
+    { print }
+  ' "$file" > "$tmp"
+
+  # If the key was the final entry, the preceding line now has a trailing comma
+  # before the closing brace. Find the last content line and strip it.
+  awk '
+    { lines[NR] = $0 }
+    END {
+      last_content = 0
+      for (i = NR; i >= 1; i--) {
+        if (lines[i] ~ /^[[:space:]]*}[[:space:]]*$/) continue
+        last_content = i
+        break
+      }
+      if (last_content > 0) sub(/,[[:space:]]*$/, "", lines[last_content])
+      for (i = 1; i <= NR; i++) print lines[i]
+    }
+  ' "$tmp" > "${tmp}.2" && mv "${tmp}.2" "$file"
+  rm -f "$tmp"
+}
+
+# --- Operation: set-checkpoint ---
+if [[ "$OPERATION" == "set-checkpoint" ]]; then
+  if [[ -z "$SUMMARY_TEXT" ]]; then
+    echo "Error: --set-checkpoint requires --summary-text" >&2
+    exit 1
+  fi
+
+  if [[ -n "$PHASE" && ! "$PHASE" =~ ^[0-9]+$ ]]; then
+    echo "Error: --phase must be a non-negative integer (got '${PHASE}')" >&2
+    exit 1
+  fi
+
+  if $HAS_JQ; then
+    TMP="$(mktemp)"
+    DECISIONS_JSON="[]"
+    if [[ -n "$PENDING_DECISIONS" ]]; then
+      DECISIONS_JSON="$(printf '%s' "$PENDING_DECISIONS" | tr '|' '\n' | jq -R '.' | jq -s '.')"
+    fi
+    WORKTREES_JSON="[]"
+    if [[ -n "$ACTIVE_WORKTREES" ]]; then
+      WORKTREES_JSON="$(printf '%s' "$ACTIVE_WORKTREES" | tr ',' '\n' | jq -R '.' | jq -s '.')"
+    fi
+
+    jq --arg sid "$SESSION_ID" \
+      --arg aid "$AGENT_ID" \
+      --arg phase "$PHASE" \
+      --arg now "$NOW" \
+      --arg summary "$SUMMARY_TEXT" \
+      --argjson decisions "$DECISIONS_JSON" \
+      --argjson worktrees "$WORKTREES_JSON" \
+      '.checkpoint = {
+        session_id: $sid,
+        agent_id: $aid,
+        phase: (if $phase == "" then null else ($phase | tonumber) end),
+        timestamp: $now,
+        orchestrator_summary: $summary,
+        pending_decisions: $decisions,
+        environment_state: { active_worktrees: $worktrees }
+      }' "$MANIFEST" > "$TMP" && mv "$TMP" "$MANIFEST"
+  else
+    strip_top_level_key "$MANIFEST" "checkpoint"
+
+    ESC_SUMMARY="$(json_escape "$SUMMARY_TEXT")"
+    ESC_SID="$(json_escape "$SESSION_ID")"
+    ESC_AID="$(json_escape "$AGENT_ID")"
+
+    DECISIONS_JSON="[]"
+    if [[ -n "$PENDING_DECISIONS" ]]; then
+      DECISIONS_JSON="$(printf '%s' "$PENDING_DECISIONS" | awk -F'|' '{
+        out = "["
+        for (i = 1; i <= NF; i++) {
+          v = $i
+          gsub(/\\/, "\\\\", v)
+          gsub(/"/, "\\\"", v)
+          out = out (i > 1 ? ", " : "") "\"" v "\""
+        }
+        printf "%s]", out
+      }')"
+    fi
+
+    WORKTREES_JSON="[]"
+    if [[ -n "$ACTIVE_WORKTREES" ]]; then
+      WORKTREES_JSON="$(printf '%s' "$ACTIVE_WORKTREES" | awk -F',' '{
+        out = "["
+        for (i = 1; i <= NF; i++) {
+          v = $i
+          gsub(/^[ \t]+|[ \t]+$/, "", v)
+          gsub(/"/, "\\\"", v)
+          out = out (i > 1 ? ", " : "") "\"" v "\""
+        }
+        printf "%s]", out
+      }')"
+    fi
+
+    PHASE_JSON="null"
+    if [[ -n "$PHASE" ]]; then
+      PHASE_JSON="$PHASE"
+    fi
+
+    # Insert as the first key so no trailing-comma repair is needed.
+    TMP="$(mktemp)"
+    awk -v sid="$ESC_SID" -v aid="$ESC_AID" -v phase="$PHASE_JSON" \
+      -v now="$NOW" -v summary="$ESC_SUMMARY" \
+      -v decisions="$DECISIONS_JSON" -v worktrees="$WORKTREES_JSON" '
+      NR == 1 && /^[[:space:]]*\{[[:space:]]*$/ {
+        print
+        print "  \"checkpoint\": {"
+        print "    \"session_id\": \"" sid "\","
+        print "    \"agent_id\": \"" aid "\","
+        print "    \"phase\": " phase ","
+        print "    \"timestamp\": \"" now "\","
+        print "    \"orchestrator_summary\": \"" summary "\","
+        print "    \"pending_decisions\": " decisions ","
+        print "    \"environment_state\": { \"active_worktrees\": " worktrees " }"
+        print "  },"
+        next
+      }
+      { print }
+    ' "$MANIFEST" > "$TMP" && mv "$TMP" "$MANIFEST"
+  fi
+
+  echo "Checkpoint written at $NOW"
+  exit 0
+fi
+
+# --- Operation: get-checkpoint ---
+if [[ "$OPERATION" == "get-checkpoint" ]]; then
+  if $HAS_JQ; then
+    if [[ "$(jq -r 'has("checkpoint")' "$MANIFEST")" != "true" ]]; then
+      echo "No checkpoint recorded." >&2
+      exit 1
+    fi
+    jq -r '.checkpoint | to_entries[] | "\(.key)=\(.value | if type == "array" or type == "object" then tojson else . end)"' "$MANIFEST"
+  else
+    if ! grep -q '"checkpoint"' "$MANIFEST"; then
+      echo "No checkpoint recorded." >&2
+      exit 1
+    fi
+    awk '
+      !inck && /^[[:space:]]*"checkpoint"[[:space:]]*:/ {
+        inck = 1
+        opens = gsub(/[{[]/, "&")
+        closes = gsub(/[}\]]/, "&")
+        depth = opens - closes
+        next
+      }
+      inck {
+        opens = gsub(/[{[]/, "&")
+        closes = gsub(/[}\]]/, "&")
+        line = $0
+        depth += opens - closes
+        if (depth <= 0) { inck = 0 }
+        idx = index(line, ":")
+        if (idx > 0) {
+          k = substr(line, 1, idx - 1)
+          v = substr(line, idx + 1)
+          gsub(/^[ \t]+|[ \t]+$/, "", k)
+          gsub(/^"|"$/, "", k)
+          gsub(/^[ \t]+|[ \t,]+$/, "", v)
+          gsub(/^"|"$/, "", v)
+          if (k != "" && v != "") print k "=" v
+        }
+      }
+    ' "$MANIFEST"
+  fi
+  exit 0
+fi
+
+# --- Operation: clear-checkpoint ---
+if [[ "$OPERATION" == "clear-checkpoint" ]]; then
+  if $HAS_JQ; then
+    TMP="$(mktemp)"
+    jq 'del(.checkpoint)' "$MANIFEST" > "$TMP" && mv "$TMP" "$MANIFEST"
+  else
+    strip_top_level_key "$MANIFEST" "checkpoint"
+  fi
+  echo "Checkpoint cleared."
+  exit 0
+fi
+
+# --- Operation: set-criteria ---
+if [[ "$OPERATION" == "set-criteria" ]]; then
+  if [[ -z "$TASK_ID" || -z "$CRITERIA" ]]; then
+    echo "Error: --set-criteria requires --task-id and --criteria" >&2
+    exit 1
+  fi
+
+  if ! grep -q "\"id\": \"${TASK_ID}\"" "$MANIFEST"; then
+    echo "Error: task $TASK_ID not found" >&2
+    exit 1
+  fi
+
+  # Criteria arrive pipe-separated and are always written as a single line, so
+  # the same insertion works for one-line and jq-formatted task objects.
+  CRITERIA_JSON="$(printf '%s' "$CRITERIA" | awk -F'|' '{
+    out = "["
+    for (i = 1; i <= NF; i++) {
+      v = $i
+      gsub(/^[ \t]+|[ \t]+$/, "", v)
+      gsub(/\\/, "\\\\", v)
+      gsub(/"/, "\\\"", v)
+      out = out (i > 1 ? ", " : "") "{\"description\": \"" v "\", \"verified\": false, \"verified_at\": null}"
+    }
+    printf "%s]", out
+  }')"
+
+  if $HAS_JQ; then
+    TMP="$(mktemp)"
+    jq --arg id "$TASK_ID" --argjson crit "$CRITERIA_JSON" \
+      '(.tasks[] | select(.id == $id)).acceptance_criteria = $crit' \
+      "$MANIFEST" > "$TMP" && mv "$TMP" "$MANIFEST"
+  else
+    TMP="$(mktemp)"
+    awk -v id="$TASK_ID" -v crit="$CRITERIA_JSON" '
+      {
+        line = $0
+        if (index(line, "\"id\": \"" id "\"") > 0) {
+          if (index(line, "}") > 0) {
+            # Single-line task object: splice before its closing brace.
+            pos = length(line)
+            while (pos > 0 && substr(line, pos, 1) != "}") pos--
+            head = substr(line, 1, pos - 1)
+            tail = substr(line, pos)
+            sub(/[ \t]+$/, "", head)
+            # Drop any existing acceptance_criteria before re-adding.
+            gsub(/, "acceptance_criteria": \[[^]]*\]/, "", head)
+            print head ", \"acceptance_criteria\": " crit tail
+            next
+          } else {
+            # Multi-line task object: insert as the next field.
+            print line
+            print "      \"acceptance_criteria\": " crit ","
+            next
+          }
+        }
+        print line
+      }
+    ' "$MANIFEST" > "$TMP" && mv "$TMP" "$MANIFEST"
+  fi
+
+  echo "Acceptance criteria set for task $TASK_ID"
+  exit 0
+fi
+
+# --- Operation: verify-criterion ---
+if [[ "$OPERATION" == "verify-criterion" ]]; then
+  if [[ -z "$TASK_ID" || -z "$CRITERION_INDEX" ]]; then
+    echo "Error: --verify-criterion requires --task-id and --criterion-index" >&2
+    exit 1
+  fi
+
+  if [[ ! "$CRITERION_INDEX" =~ ^[0-9]+$ ]]; then
+    echo "Error: --criterion-index must be a non-negative integer (got '${CRITERION_INDEX}')" >&2
+    exit 1
+  fi
+
+  if $HAS_JQ; then
+    COUNT="$(jq -r --arg id "$TASK_ID" \
+      '[.tasks[] | select(.id == $id) | .acceptance_criteria // []] | first | length' "$MANIFEST")"
+    if [[ "$COUNT" == "null" || "$COUNT" == "0" ]]; then
+      echo "Error: task $TASK_ID has no acceptance criteria" >&2
+      exit 1
+    fi
+    if [[ "$CRITERION_INDEX" -ge "$COUNT" ]]; then
+      echo "Error: criterion index ${CRITERION_INDEX} out of range (0..$((COUNT - 1)))" >&2
+      exit 1
+    fi
+    TMP="$(mktemp)"
+    jq --arg id "$TASK_ID" --argjson idx "$CRITERION_INDEX" --arg now "$NOW" \
+      '(.tasks[] | select(.id == $id) | .acceptance_criteria[$idx]) |=
+        (.verified = true | .verified_at = $now)' \
+      "$MANIFEST" > "$TMP" && mv "$TMP" "$MANIFEST"
+  else
+    if ! grep -q "\"id\": \"${TASK_ID}\"" "$MANIFEST"; then
+      echo "Error: task $TASK_ID not found" >&2
+      exit 1
+    fi
+    TMP="$(mktemp)"
+    RESULT="$(awk -v id="$TASK_ID" -v want="$CRITERION_INDEX" -v now="$NOW" -v out="$TMP" '
+      BEGIN { found = 0 }
+      {
+        line = $0
+        if (index(line, "\"id\": \"" id "\"") > 0 && index(line, "acceptance_criteria") > 0) {
+          # Walk the criterion objects and flip the requested one.
+          n = 0
+          result = ""
+          rest = line
+          while (1) {
+            p = index(rest, "{\"description\"")
+            if (p == 0) { result = result rest; break }
+            q = index(substr(rest, p), "}")
+            if (q == 0) { result = result rest; break }
+            obj = substr(rest, p, q)
+            result = result substr(rest, 1, p - 1)
+            if (n == want) {
+              gsub(/"verified": false/, "\"verified\": true", obj)
+              gsub(/"verified_at": null/, "\"verified_at\": \"" now "\"", obj)
+              found = 1
+            }
+            result = result obj
+            rest = substr(rest, p + q)
+            n++
+          }
+          print result > out
+          next
+        }
+        print line > out
+      }
+      END { print (found ? "ok" : "notfound") }
+    ' "$MANIFEST")"
+
+    if [[ "$RESULT" != "ok" ]]; then
+      rm -f "$TMP"
+      echo "Error: criterion index ${CRITERION_INDEX} not found for task ${TASK_ID}" >&2
+      echo "Note: without jq, criteria must be on the same line as the task id." >&2
+      exit 1
+    fi
+    mv "$TMP" "$MANIFEST"
+  fi
+
+  echo "Criterion ${CRITERION_INDEX} verified for task $TASK_ID"
+  exit 0
+fi
+
+# --- Operation: list-criteria ---
+if [[ "$OPERATION" == "list-criteria" ]]; then
+  if [[ -z "$TASK_ID" ]]; then
+    echo "Error: --list-criteria requires --task-id" >&2
+    exit 1
+  fi
+
+  if $HAS_JQ; then
+    jq -r --arg id "$TASK_ID" '
+      [.tasks[] | select(.id == $id) | .acceptance_criteria // []] | first // []
+      | to_entries[]
+      | "\(.key)|\(if .value.verified then "verified" else "pending" end)|\(.value.description)"
+    ' "$MANIFEST"
+  else
+    awk -v id="$TASK_ID" '
+      index($0, "\"id\": \"" id "\"") > 0 && index($0, "acceptance_criteria") > 0 {
+        n = 0
+        rest = $0
+        while (1) {
+          p = index(rest, "{\"description\"")
+          if (p == 0) break
+          q = index(substr(rest, p), "}")
+          if (q == 0) break
+          obj = substr(rest, p, q)
+
+          d = obj
+          sub(/.*"description": "/, "", d)
+          sub(/".*/, "", d)
+
+          state = (index(obj, "\"verified\": true") > 0) ? "verified" : "pending"
+          print n "|" state "|" d
+
+          rest = substr(rest, p + q)
+          n++
+        }
+      }
+    ' "$MANIFEST"
   fi
   exit 0
 fi

--- a/plugins/principled-implementation/skills/impl-strategy/reference/manifest-schema.md
+++ b/plugins/principled-implementation/skills/impl-strategy/reference/manifest-schema.md
@@ -77,6 +77,86 @@ The task manifest at `.impl/manifest.json` is the single source of truth for orc
 | `created_at`       | string         | ISO 8601 timestamp of task creation                     |
 | `updated_at`       | string         | ISO 8601 timestamp of last status change                |
 
+### Checkpoint Object (optional, ADR-021)
+
+A top-level `checkpoint` key carrying the natural-language reasoning that structured task
+state cannot. Absent from manifests written before ADR-021, and absence is valid.
+
+```json
+{
+  "checkpoint": {
+    "session_id": "sess-abc123",
+    "agent_id": "impl-worker",
+    "phase": 2,
+    "timestamp": "2026-07-28T14:30:00Z",
+    "orchestrator_summary": "Phase 1 complete (3/3 merged). task-2b failed on the test suite twice — needs a different approach, not a retry.",
+    "pending_decisions": ["task-2b: response format — envelope vs flat"],
+    "environment_state": {
+      "active_worktrees": ["task-2a", "task-2b"]
+    }
+  }
+}
+```
+
+| Field                  | Type           | Description                                       |
+| ---------------------- | -------------- | ------------------------------------------------- |
+| `session_id`           | string         | Session that wrote the checkpoint                 |
+| `agent_id`             | string         | Agent that wrote it                               |
+| `phase`                | number or null | Phase in progress when written                    |
+| `timestamp`            | string         | ISO 8601 write time                               |
+| `orchestrator_summary` | string         | Reasoning for a session that has no other context |
+| `pending_decisions`    | string[]       | Unresolved questions blocking progress            |
+| `environment_state`    | object         | `active_worktrees`, and branch names where known  |
+
+**The checkpoint is advisory. The task array is authoritative.** A checkpoint may be
+written by a session that was failing at the time, so it can describe a state that no
+longer holds. Consumers use it as context for the model, never as a source of truth for
+control flow; on disagreement, task state wins and the divergence is reported.
+
+### Acceptance Criteria (optional, ADR-021)
+
+An optional `acceptance_criteria` array on a task, making each criterion individually
+addressable so an interrupted task resumes from the first unverified one rather than
+from zero.
+
+```json
+{
+  "id": "2.1",
+  "status": "in_progress",
+  "acceptance_criteria": [
+    {
+      "description": "Rejects missing auth with 401",
+      "verified": true,
+      "verified_at": "2026-07-28T14:20:00Z"
+    },
+    {
+      "description": "Unit tests cover both cases",
+      "verified": false,
+      "verified_at": null
+    }
+  ]
+}
+```
+
+| Field         | Type           | Description                           |
+| ------------- | -------------- | ------------------------------------- |
+| `description` | string         | The criterion, as written in the plan |
+| `verified`    | boolean        | Whether the agent has confirmed it    |
+| `verified_at` | string or null | ISO 8601 time of verification         |
+
+Criteria are a **property of a task, not a fourth hierarchy level**. Plan → Phase → Task
+is unchanged (ADR-008), and tasks remain the unit of decomposition, spawning, validation
+and merge.
+
+`verified: true` is a claim by the agent that did the work, not a proof. `/check-impl`
+remains the acceptance gate; criteria are a resumption hint.
+
+## Compatibility
+
+Both fields above are additive and optional. Consumers must tolerate their absence and
+must not fail on unknown fields. No migration runs — a manifest gains a checkpoint the
+first time something writes one.
+
 ## Valid Status Values
 
 `pending`, `in_progress`, `validating`, `passed`, `failed`, `merged`, `abandoned`, `conflict`

--- a/plugins/principled-implementation/skills/resume/SKILL.md
+++ b/plugins/principled-implementation/skills/resume/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: resume
+description: >
+  Resume an interrupted orchestration run. Reads the manifest checkpoint for the
+  previous session's reasoning, reports divergence against the task graph, and
+  continues from the first unverified acceptance criterion. Use after a session
+  ends mid-plan, or when picking up work started elsewhere.
+allowed-tools: Read, Write, Edit, Bash(bash plugins/*), Bash(bash scripts/*), Bash(git *), Bash(ls *), Bash(cat *)
+user-invocable: true
+---
+
+# Resume — Continue an Interrupted Run
+
+Pick up an orchestration run where a previous session left off, with its reasoning
+intact rather than just its task state.
+
+## Command
+
+```
+/resume [<plan-path>] [--from-checkpoint] [--replan]
+```
+
+## Arguments
+
+| Argument            | Required | Description                                                       |
+| ------------------- | -------- | ----------------------------------------------------------------- |
+| `<plan-path>`       | No       | Plan to resume. Read from the manifest when omitted               |
+| `--from-checkpoint` | No       | Trust the checkpoint's phase as the resumption point              |
+| `--replan`          | No       | Re-derive remaining work from task state, ignoring the checkpoint |
+
+## What makes this different from `--continue`
+
+`/orchestrate --continue` resumes mechanically from task state. It can see that task-2b
+is `failed` with `retries: 2`; it cannot see that both failures were the same test
+failure and that retrying a third time is the wrong move.
+
+The checkpoint carries that reasoning. `/resume` reads it, so the new session inherits
+the previous one's conclusions rather than rediscovering them.
+
+## The authority rule
+
+**The checkpoint is advisory. Task state is authoritative** (ADR-021).
+
+A checkpoint is written by a session that may have been failing when it wrote it, so it
+can describe a state that no longer holds or never held. Where the two disagree, believe
+the task array and report the disagreement. Never edit task state to match a checkpoint.
+
+## Workflow
+
+1. **Read the manifest.** Fail clearly if there is none — there is nothing to resume:
+
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/lib/task-manifest.sh" --summary
+   ```
+
+2. **Read the checkpoint.** Exits non-zero when none was recorded, which is normal for a
+   run that ended cleanly:
+
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/lib/task-manifest.sh" --get-checkpoint
+   ```
+
+   Present `orchestrator_summary` and `pending_decisions` to the user before doing
+   anything. That prose is the point of the command.
+
+3. **Reconcile the checkpoint against task state.** For each claim the summary makes
+   about a task, compare it with the task's actual status. Report every mismatch:
+
+   > Checkpoint says task-2a merged; manifest has it `failed`. Believing the manifest.
+
+   Skip this step entirely under `--replan`.
+
+4. **Report divergence against the task graph.** Only when principled-tasks is in use —
+   check for `.principled/tasks.jsonl` first and skip the whole step silently if it is
+   absent, since principled-tasks is an independent install:
+
+   Join manifest tasks to graph tasks on `plan` plus `task_id` and report:
+   - manifest tasks with no corresponding graph task
+   - graph tasks for this plan with no manifest task
+   - tasks whose statuses disagree
+
+   **Report only. Never write to the task graph to make it match**, and never edit the
+   manifest to match the graph. A disagreement is usually evidence that a session died
+   between the two writes, and that evidence is worth more than tidy agreement.
+
+5. **Determine the resumption point.**
+   - `--from-checkpoint`: start at the checkpoint's `phase`.
+   - `--replan`: ignore the checkpoint and derive remaining work from task state alone.
+   - Default: derive from task state, using the checkpoint only as context.
+
+6. **Check acceptance criteria on in-flight tasks.** A task interrupted mid-execution
+   may have criteria already verified:
+
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/lib/task-manifest.sh" --list-criteria --task-id <id>
+   ```
+
+   Resume from the first `pending` criterion rather than restarting the task. Criteria
+   are a resumption hint, not an acceptance gate — `/check-impl` remains the actual gate,
+   and a task with every criterion ticked is still not done until its checks pass.
+
+7. **Verify the environment.** Worktrees named in `environment_state` may be gone
+   (ADR-007 worktrees survive session death, but not `git worktree prune`). Confirm each
+   still exists and report any that do not.
+
+8. **Continue.** Hand off to `/orchestrate --continue`, or spawn the next task directly
+   with `/spawn <task-id>`.
+
+9. **Write a fresh checkpoint** before doing significant work, so this session is itself
+   resumable:
+
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/lib/task-manifest.sh" --set-checkpoint \
+     --agent-id orchestrator --phase <N> \
+     --summary-text "<what is done, what failed and why, what to do next>"
+   ```
+
+   Write the summary for a reader who has none of your context. "task-2b failed twice on
+   the same fixture collision — change the approach, do not retry" is useful; "phase 2 in
+   progress" is not.
+
+## Reporting
+
+Lead with the previous session's reasoning, then the current state, then divergences,
+then the plan. Say explicitly when there was no checkpoint, when the task graph was not
+consulted, and when the checkpoint disagreed with task state — silence on any of those
+reads as confirmation the resume was clean.
+
+## Scripts
+
+- `${CLAUDE_PLUGIN_ROOT}/lib/task-manifest.sh` — manifest interface, including
+  checkpoint and criteria operations (ADR-018, ADR-021)

--- a/tests/agent-memory.bats
+++ b/tests/agent-memory.bats
@@ -1,0 +1,254 @@
+#!/usr/bin/env bats
+# Tests for plugins/principled-agent/lib/agent-memory.sh
+#
+# Memory is a document, not an event log (ADR-020), which means the risky operations
+# are the ones that rewrite a file in place: metric updates must not disturb the
+# knowledge body, and a reset must not disturb it either. The size budget is advisory
+# by design, so these tests also pin down that it warns without ever failing or
+# truncating — a budget that silently dropped content would be worse than no budget.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+  LIB="${REPO_ROOT}/plugins/principled-agent/lib/agent-memory.sh"
+  WORK="${BATS_TEST_TMPDIR}/work"
+  mkdir -p "$WORK"
+  cd "$WORK" || return 1
+  git init -q -b main .
+  git config user.email test@example.com
+  git config user.name "Test"
+  # See tests/task-db.bats: fsmonitor/auto-gc daemons inherit bats' stdout and
+  # prevent it from ever seeing EOF, hanging the run after all tests pass.
+  git config core.fsmonitor false
+  git config gc.auto 0
+  bash "$LIB" --init > /dev/null
+  MEM=".agents/memory/agents/impl-worker.md"
+  make_nojq_path
+}
+
+# Build a PATH that genuinely lacks jq. Trimming to /usr/bin:/bin does not work,
+# because jq lives in /usr/bin on macOS.
+make_nojq_path() {
+  NOJQ_BIN="${BATS_TEST_TMPDIR}/nojq-bin"
+  [[ -d "$NOJQ_BIN" ]] && return 0
+  mkdir -p "$NOJQ_BIN"
+  local tool src
+  for tool in bash sh cat grep sed head tail cut awk tr sort uniq wc find xargs \
+    basename dirname date git ls mkdir rm mv cp touch printf env test expr mktemp; do
+    src="$(command -v "$tool" 2> /dev/null || true)"
+    [[ -n "$src" ]] && ln -sf "$src" "${NOJQ_BIN}/${tool}"
+  done
+}
+
+run_without_jq() {
+  env -i "PATH=${NOJQ_BIN}" "HOME=${HOME}" bash "$LIB" "$@"
+}
+
+# --- Scaffold ---
+
+@test "init creates the registry, global memory, and per-agent files" {
+  [ -f .agents/registry.json ]
+  [ -f .agents/memory/global.md ]
+  [ -f .agents/memory/agents/impl-worker.md ]
+  [ -d .agents/retrospectives ]
+}
+
+@test "init seeds memory only for agents the registry marks memory:true" {
+  [ -f .agents/memory/agents/impl-worker.md ]
+  [ -f .agents/memory/agents/issue-ingester.md ]
+  [ -f .agents/memory/agents/pr-reviewer.md ]
+  # Deterministic auditors learn nothing, so they get no file.
+  [ ! -f .agents/memory/agents/module-auditor.md ]
+  [ ! -f .agents/memory/agents/boundary-checker.md ]
+}
+
+@test "init is idempotent and never overwrites existing knowledge" {
+  printf -- '- a hard-won fact\n' >> "$MEM"
+  run bash "$LIB" --init
+  [ "$status" -eq 0 ]
+  grep -q 'a hard-won fact' "$MEM"
+}
+
+@test "memory files carry parseable frontmatter" {
+  [ "$(head -1 "$MEM")" = "---" ]
+  run bash "$LIB" --show --agent impl-worker --frontmatter-only
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'agent_id: "impl-worker"'
+}
+
+# --- Metrics ---
+
+@test "update-metrics computes a running success rate" {
+  bash "$LIB" --update-metrics --agent impl-worker --session --tasks 4 --succeeded 3
+  run bash "$LIB" --show --agent impl-worker --frontmatter-only
+  echo "$output" | grep -q 'success_rate: 0.75'
+  echo "$output" | grep -q 'total_tasks: 4'
+  echo "$output" | grep -q 'session_count: 1'
+}
+
+@test "success rate accumulates across sessions rather than being overwritten" {
+  bash "$LIB" --update-metrics --agent impl-worker --session --tasks 4 --succeeded 3
+  bash "$LIB" --update-metrics --agent impl-worker --session --tasks 4 --succeeded 4
+  run bash "$LIB" --show --agent impl-worker --frontmatter-only
+  # 3 of 4, then 4 of 4, is 7 of 8 — not the 1.0 of the latest run alone.
+  echo "$output" | grep -q 'success_rate: 0.88'
+  echo "$output" | grep -q 'total_tasks: 8'
+  echo "$output" | grep -q 'session_count: 2'
+}
+
+@test "updating metrics leaves the knowledge body untouched" {
+  printf -- '- macOS ships bash 3.2, so no `declare -A`.\n' >> "$MEM"
+  bash "$LIB" --update-metrics --agent impl-worker --session --tasks 2 --succeeded 1
+  grep -q 'macOS ships bash 3.2' "$MEM"
+  grep -q '## Known Patterns' "$MEM"
+}
+
+@test "non-numeric metric arguments are rejected" {
+  run bash "$LIB" --update-metrics --agent impl-worker --tasks abc
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q 'non-negative integers'
+}
+
+@test "more successes than tasks is rejected" {
+  run bash "$LIB" --update-metrics --agent impl-worker --tasks 1 --succeeded 5
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q 'cannot exceed'
+}
+
+@test "operating on an unknown agent fails loudly" {
+  run bash "$LIB" --update-metrics --agent no-such-agent --session
+  [ "$status" -eq 1 ]
+}
+
+# --- Forks ---
+
+@test "reset-metrics zeroes counters but preserves knowledge" {
+  printf -- '- knowledge that must survive a fork\n' >> "$MEM"
+  bash "$LIB" --update-metrics --agent impl-worker --session --tasks 9 --succeeded 9
+  bash "$LIB" --reset-metrics --agent impl-worker
+  run bash "$LIB" --show --agent impl-worker --frontmatter-only
+  echo "$output" | grep -q 'session_count: 0'
+  echo "$output" | grep -q 'total_tasks: 0'
+  echo "$output" | grep -q 'success_rate: 0.0'
+  # The whole point: the codebase knowledge still applies in the fork.
+  grep -q 'knowledge that must survive a fork' "$MEM"
+}
+
+@test "reset-metrics with no agent resets every memory-bearing agent" {
+  bash "$LIB" --update-metrics --agent impl-worker --session --tasks 3 --succeeded 3
+  bash "$LIB" --update-metrics --agent pr-reviewer --session --tasks 3 --succeeded 3
+  bash "$LIB" --reset-metrics
+  run bash "$LIB" --show --agent impl-worker --frontmatter-only
+  echo "$output" | grep -q 'total_tasks: 0'
+  run bash "$LIB" --show --agent pr-reviewer --frontmatter-only
+  echo "$output" | grep -q 'total_tasks: 0'
+}
+
+# --- Size budget ---
+
+@test "a memory file under budget reports OK" {
+  run bash "$LIB" --check --agent impl-worker
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q '^OK: impl-worker'
+}
+
+@test "exceeding the soft budget warns without failing" {
+  # ~200 lines of ~52 bytes clears 8192 while staying well under the 16384 hard limit.
+  awk 'BEGIN { for (i = 0; i < 200; i++) print "- a durable fact about this codebase worth keeping." }' >> "$MEM"
+  run bash "$LIB" --check --agent impl-worker
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'soft budget'
+}
+
+@test "exceeding the hard budget still only warns" {
+  awk 'BEGIN { for (i = 0; i < 400; i++) print "- a durable fact about this codebase worth keeping." }' >> "$MEM"
+  run bash "$LIB" --check --agent impl-worker
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'over the 16384 byte budget'
+}
+
+@test "an oversized memory file is never truncated" {
+  awk 'BEGIN { for (i = 0; i < 400; i++) print "- padding" }' >> "$MEM"
+  printf -- '- THE LAST LINE MUST SURVIVE\n' >> "$MEM"
+  before="$(wc -c < "$MEM")"
+  bash "$LIB" --check --agent impl-worker
+  after="$(wc -c < "$MEM")"
+  [ "$before" -eq "$after" ]
+  # Truncation would drop the tail first, so assert on the tail specifically.
+  grep -q 'THE LAST LINE MUST SURVIVE' "$MEM"
+}
+
+# --- Structural integrity ---
+
+@test "a missing memory file for a registered agent is an error" {
+  rm .agents/memory/agents/issue-ingester.md
+  run bash "$LIB" --check
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q 'ERROR: issue-ingester'
+}
+
+@test "an agent_id that disagrees with the filename is an error" {
+  sed 's/agent_id: "pr-reviewer"/agent_id: "someone-else"/' .agents/memory/agents/pr-reviewer.md > tmp
+  mv tmp .agents/memory/agents/pr-reviewer.md
+  run bash "$LIB" --check --agent pr-reviewer
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q "expected 'pr-reviewer'"
+}
+
+@test "missing frontmatter is an error" {
+  printf 'no frontmatter here\n' > "$MEM"
+  run bash "$LIB" --check --agent impl-worker
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q 'missing YAML frontmatter'
+}
+
+# --- Output formats ---
+
+@test "json format is honored rather than silently ignored" {
+  run bash "$LIB" --list --format json
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q '"agents"'
+  echo "$output" | grep -q '"id": "impl-worker"'
+}
+
+@test "unknown format is rejected" {
+  run bash "$LIB" --list --format yaml
+  [ "$status" -eq 1 ]
+}
+
+@test "an unknown argument exits non-zero rather than being ignored" {
+  run bash "$LIB" --list --bogus-flag
+  [ "$status" -eq 1 ]
+}
+
+@test "no operation exits non-zero with usage" {
+  run bash "$LIB"
+  [ "$status" -eq 1 ]
+}
+
+# --- Without jq ---
+# The repository documents jq as optional, so the fallback paths must actually work.
+
+@test "list works without jq" {
+  run run_without_jq --list
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'impl-worker'
+}
+
+@test "check works without jq" {
+  run run_without_jq --check
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'OK: impl-worker'
+}
+
+@test "update-metrics works without jq" {
+  run run_without_jq --update-metrics --agent impl-worker --session --tasks 2 --succeeded 1
+  [ "$status" -eq 0 ]
+  run bash "$LIB" --show --agent impl-worker --frontmatter-only
+  echo "$output" | grep -q 'success_rate: 0.50'
+}
+
+@test "the registry is read identically with and without jq" {
+  with_jq="$(bash "$LIB" --list | awk 'NR > 1 { print $1 }' | sort)"
+  without_jq="$(run_without_jq --list | awk 'NR > 1 { print $1 }' | sort)"
+  [ "$with_jq" = "$without_jq" ]
+}

--- a/tests/hooks.bats
+++ b/tests/hooks.bats
@@ -21,8 +21,26 @@ setup() {
   REL_HOOKS="${REPO_ROOT}/plugins/principled-release/hooks/scripts"
   ARCH_HOOKS="${REPO_ROOT}/plugins/principled-architecture/hooks/scripts"
   TASK_HOOKS="${REPO_ROOT}/plugins/principled-tasks/hooks/scripts"
+  AGENT_HOOKS="${REPO_ROOT}/plugins/principled-agent/hooks/scripts"
   cd "$REPO_ROOT" || return 1
   make_nojq_path
+}
+
+# Build a throwaway repository with a scaffolded .agents/ directory, for the
+# principled-agent hooks. They read from the repository root, so they need a real
+# one rather than a bare temp directory.
+make_agents_repo() {
+  AGENT_REPO="${BATS_TEST_TMPDIR}/agents-repo"
+  mkdir -p "$AGENT_REPO"
+  (
+    cd "$AGENT_REPO" || exit 1
+    git init -q -b main .
+    git config user.email test@example.com
+    git config user.name "Test"
+    git config core.fsmonitor false
+    git config gc.auto 0
+    bash "${REPO_ROOT}/plugins/principled-agent/lib/agent-memory.sh" --init > /dev/null
+  )
 }
 
 # Build a PATH that genuinely lacks jq.
@@ -307,4 +325,125 @@ run_without_jq() {
       return 1
     }
   done
+}
+
+# --- Agent memory injection (principled-agent) ---
+#
+# This hook runs on SubagentStart, so a failure here would block agent spawning
+# entirely. Every path must exit 0, including the ones where it can do nothing.
+
+@test "memory injection emits the agent's knowledge at spawn" {
+  make_agents_repo
+  printf -- '- macOS ships bash 3.2, so no `declare -A`.\n' >> "${AGENT_REPO}/.agents/memory/agents/impl-worker.md"
+  run bash -c "cd '${AGENT_REPO}' && echo '{\"agent_id\":\"impl-worker\"}' | bash '${AGENT_HOOKS}/inject-agent-memory.sh' 2>&1"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'macOS ships bash 3.2'
+}
+
+@test "memory injection emits global memory alongside the agent's own" {
+  make_agents_repo
+  printf -- '- every agent should know this.\n' >> "${AGENT_REPO}/.agents/memory/global.md"
+  run bash -c "cd '${AGENT_REPO}' && echo '{\"agent_id\":\"impl-worker\"}' | bash '${AGENT_HOOKS}/inject-agent-memory.sh' 2>&1"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'every agent should know this'
+}
+
+@test "memory injection stays silent for an agent that carries no memory" {
+  make_agents_repo
+  printf -- '- every agent should know this.\n' >> "${AGENT_REPO}/.agents/memory/global.md"
+  run bash -c "cd '${AGENT_REPO}' && echo '{\"agent_id\":\"module-auditor\"}' | bash '${AGENT_HOOKS}/inject-agent-memory.sh' 2>&1"
+  [ "$status" -eq 0 ]
+  # module-auditor runs a deterministic script and learns nothing (RFC-011), so it
+  # must receive nothing at all — not even global memory, which would spend context
+  # budget for no possible benefit.
+  [ -z "$output" ]
+}
+
+@test "memory injection does not truncate an oversized file" {
+  make_agents_repo
+  local mem="${AGENT_REPO}/.agents/memory/agents/impl-worker.md"
+  awk 'BEGIN { for (i = 0; i < 400; i++) print "- padding line" }' >> "$mem"
+  printf -- '- THE FINAL FACT\n' >> "$mem"
+  run bash -c "cd '${AGENT_REPO}' && echo '{\"agent_id\":\"impl-worker\"}' | bash '${AGENT_HOOKS}/inject-agent-memory.sh' 2>&1"
+  [ "$status" -eq 0 ]
+  # Truncation would drop the tail, so assert the last line survives injection.
+  echo "$output" | grep -q 'THE FINAL FACT'
+}
+
+@test "memory injection exits 0 when no repository has been initialized" {
+  run bash -c "cd '${BATS_TEST_TMPDIR}' && echo '{\"agent_id\":\"impl-worker\"}' | bash '${AGENT_HOOKS}/inject-agent-memory.sh'"
+  [ "$status" -eq 0 ]
+}
+
+@test "memory injection exits 0 on malformed input" {
+  run bash -c "echo 'not json at all' | bash '${AGENT_HOOKS}/inject-agent-memory.sh'"
+  [ "$status" -eq 0 ]
+  run bash -c "echo '' | bash '${AGENT_HOOKS}/inject-agent-memory.sh'"
+  [ "$status" -eq 0 ]
+}
+
+@test "memory injection works without jq" {
+  make_agents_repo
+  printf -- '- a fact reachable only via the grep fallback.\n' >> "${AGENT_REPO}/.agents/memory/agents/impl-worker.md"
+  run bash -c "cd '${AGENT_REPO}' && echo '{\"agent_id\":\"impl-worker\"}' | env -i PATH='${NOJQ_BIN}' HOME='${HOME}' bash '${AGENT_HOOKS}/inject-agent-memory.sh' 2>&1"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'reachable only via the grep fallback'
+}
+
+# --- Agent memory integrity advisory (principled-agent) ---
+
+@test "memory integrity advisory ignores files outside .agents/" {
+  run bash -c "echo '{\"tool_input\":{\"file_path\":\"src/index.ts\"}}' | bash '${AGENT_HOOKS}/check-memory-integrity.sh' 2>&1"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "memory integrity advisory warns past the soft budget" {
+  make_agents_repo
+  local mem="${AGENT_REPO}/.agents/memory/agents/impl-worker.md"
+  awk 'BEGIN { for (i = 0; i < 200; i++) print "- a durable fact about this codebase worth keeping." }' >> "$mem"
+  run bash -c "echo '{\"tool_input\":{\"file_path\":\"${mem}\"}}' | bash '${AGENT_HOOKS}/check-memory-integrity.sh' 2>&1"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'soft budget'
+}
+
+@test "memory integrity advisory warns when agent_id disagrees with the filename" {
+  make_agents_repo
+  local mem="${AGENT_REPO}/.agents/memory/agents/pr-reviewer.md"
+  sed 's/agent_id: "pr-reviewer"/agent_id: "someone-else"/' "$mem" > "${mem}.tmp"
+  mv "${mem}.tmp" "$mem"
+  run bash -c "echo '{\"tool_input\":{\"file_path\":\"${mem}\"}}' | bash '${AGENT_HOOKS}/check-memory-integrity.sh' 2>&1"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'will never be injected'
+}
+
+@test "memory integrity advisory warns on missing frontmatter" {
+  make_agents_repo
+  local mem="${AGENT_REPO}/.agents/memory/agents/impl-worker.md"
+  printf 'no frontmatter here\n' > "$mem"
+  run bash -c "echo '{\"tool_input\":{\"file_path\":\"${mem}\"}}' | bash '${AGENT_HOOKS}/check-memory-integrity.sh' 2>&1"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'no YAML frontmatter'
+}
+
+@test "memory integrity advisory never blocks, whatever it finds" {
+  make_agents_repo
+  local mem="${AGENT_REPO}/.agents/memory/agents/impl-worker.md"
+  printf 'garbage\n' > "$mem"
+  run bash -c "echo '{\"tool_input\":{\"file_path\":\"${mem}\"}}' | bash '${AGENT_HOOKS}/check-memory-integrity.sh'"
+  [ "$status" -eq 0 ]
+}
+
+@test "memory integrity advisory exits 0 on malformed input" {
+  run bash -c "echo 'not json' | bash '${AGENT_HOOKS}/check-memory-integrity.sh'"
+  [ "$status" -eq 0 ]
+}
+
+@test "memory integrity advisory works without jq" {
+  make_agents_repo
+  local mem="${AGENT_REPO}/.agents/memory/agents/impl-worker.md"
+  awk 'BEGIN { for (i = 0; i < 200; i++) print "- a durable fact about this codebase worth keeping." }' >> "$mem"
+  run run_without_jq "${AGENT_HOOKS}/check-memory-integrity.sh" \
+    "{\"tool_input\":{\"file_path\":\"${mem}\"}}"
+  [ "$status" -eq 0 ]
 }

--- a/tests/manifest-checkpoint.bats
+++ b/tests/manifest-checkpoint.bats
@@ -1,0 +1,261 @@
+#!/usr/bin/env bats
+# Tests for the checkpoint and acceptance-criteria operations in
+# plugins/principled-implementation/lib/task-manifest.sh (ADR-021).
+#
+# Two classes of risk are covered.
+#
+# First, the new fields are additive and optional, so the failure mode is a consumer
+# that breaks when they are present or absent. These tests assert both shapes stay
+# valid JSON and that absence is never an error.
+#
+# Second, the no-jq fallback edits JSON with text tools. It previously used `sed -i`,
+# which is not portable: BSD sed reads the following argument as a backup suffix, so
+# `sed -i <expr> <file>` misparses on stock macOS and the fallback failed outright for
+# the second task onward and for every status update. The regression tests below pin
+# that down, since the repository documents jq as optional and CI runs on macOS.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+  LIB="${REPO_ROOT}/plugins/principled-implementation/lib/task-manifest.sh"
+  WORK="${BATS_TEST_TMPDIR}/work"
+  mkdir -p "$WORK"
+  cd "$WORK" || return 1
+  git init -q -b main .
+  git config user.email test@example.com
+  git config user.name "Test"
+  git config core.fsmonitor false
+  git config gc.auto 0
+  bash "$LIB" --init --plan-path docs/plans/008-x.md --plan-number 008 --plan-title "X" > /dev/null
+  make_nojq_path
+}
+
+make_nojq_path() {
+  NOJQ_BIN="${BATS_TEST_TMPDIR}/nojq-bin"
+  [[ -d "$NOJQ_BIN" ]] && return 0
+  mkdir -p "$NOJQ_BIN"
+  local tool src
+  for tool in bash sh cat grep sed head tail cut awk tr sort uniq wc find xargs \
+    basename dirname date git ls mkdir rm mv cp touch printf env test expr mktemp; do
+    src="$(command -v "$tool" 2> /dev/null || true)"
+    [[ -n "$src" ]] && ln -sf "$src" "${NOJQ_BIN}/${tool}"
+  done
+}
+
+nojq() {
+  env -i "PATH=${NOJQ_BIN}" "HOME=${HOME}" bash "$LIB" "$@"
+}
+
+# Validate with the real jq, which stays available to the test itself even when the
+# script under test was run without it.
+assert_valid_json() {
+  run jq . .impl/manifest.json
+  [ "$status" -eq 0 ]
+}
+
+# --- Backward compatibility ---
+
+@test "a fresh manifest has no checkpoint and that is not an error" {
+  run jq 'has("checkpoint")' .impl/manifest.json
+  [ "$output" = "false" ]
+}
+
+@test "reading an absent checkpoint fails cleanly rather than crashing" {
+  run bash "$LIB" --get-checkpoint
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q 'No checkpoint recorded'
+}
+
+@test "existing operations still work once a checkpoint is present" {
+  bash "$LIB" --add-task --task-id 1.1 --phase 1 --description "first" > /dev/null
+  bash "$LIB" --set-checkpoint --summary-text "mid-run" > /dev/null
+  run bash "$LIB" --list-tasks
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q '1.1'
+  run bash "$LIB" --summary
+  [ "$status" -eq 0 ]
+}
+
+# --- Checkpoint ---
+
+@test "set-checkpoint records the orchestrator summary verbatim" {
+  bash "$LIB" --set-checkpoint --session-id sess-abc --agent-id impl-worker --phase 2 \
+    --summary-text 'task-2b failed twice on the same fixture collision — change approach, do not retry.' > /dev/null
+  assert_valid_json
+  run bash "$LIB" --get-checkpoint
+  echo "$output" | grep -q 'change approach, do not retry'
+  echo "$output" | grep -q 'session_id=sess-abc'
+  echo "$output" | grep -q 'phase=2'
+}
+
+@test "a summary containing quotes stays valid JSON" {
+  bash "$LIB" --set-checkpoint --summary-text 'the "test suite" failed on a \ backslash' > /dev/null
+  assert_valid_json
+  run jq -r '.checkpoint.orchestrator_summary' .impl/manifest.json
+  echo "$output" | grep -q 'test suite'
+}
+
+@test "pending decisions and worktrees round-trip as arrays" {
+  bash "$LIB" --set-checkpoint --summary-text "s" \
+    --pending-decisions 'envelope vs flat|naming' \
+    --active-worktrees 'task-2a,task-2b' > /dev/null
+  assert_valid_json
+  run jq -r '.checkpoint.pending_decisions | length' .impl/manifest.json
+  [ "$output" = "2" ]
+  run jq -r '.checkpoint.environment_state.active_worktrees | length' .impl/manifest.json
+  [ "$output" = "2" ]
+}
+
+@test "writing a checkpoint twice replaces rather than duplicates it" {
+  bash "$LIB" --set-checkpoint --summary-text "first" > /dev/null
+  bash "$LIB" --set-checkpoint --summary-text "second" > /dev/null
+  assert_valid_json
+  run jq -r '.checkpoint.orchestrator_summary' .impl/manifest.json
+  [ "$output" = "second" ]
+  [ "$(grep -c '"checkpoint"' .impl/manifest.json)" -eq 1 ]
+}
+
+@test "clear-checkpoint removes it and leaves the manifest valid" {
+  bash "$LIB" --set-checkpoint --summary-text "s" > /dev/null
+  bash "$LIB" --clear-checkpoint > /dev/null
+  assert_valid_json
+  run jq 'has("checkpoint")' .impl/manifest.json
+  [ "$output" = "false" ]
+}
+
+@test "set-checkpoint requires a summary" {
+  run bash "$LIB" --set-checkpoint --session-id x
+  [ "$status" -eq 1 ]
+}
+
+@test "a non-numeric phase is rejected" {
+  run bash "$LIB" --set-checkpoint --summary-text "s" --phase two
+  [ "$status" -eq 1 ]
+}
+
+# --- Acceptance criteria ---
+
+@test "criteria are stored unverified and listed in order" {
+  bash "$LIB" --add-task --task-id 2.1 --phase 2 --description "auth" > /dev/null
+  bash "$LIB" --set-criteria --task-id 2.1 --criteria "rejects 401|passes valid|tests cover" > /dev/null
+  assert_valid_json
+  run bash "$LIB" --list-criteria --task-id 2.1
+  echo "$output" | grep -q '^0|pending|rejects 401'
+  echo "$output" | grep -q '^2|pending|tests cover'
+}
+
+@test "verifying a criterion flips only that one and stamps a time" {
+  bash "$LIB" --add-task --task-id 2.1 --phase 2 --description "auth" > /dev/null
+  bash "$LIB" --set-criteria --task-id 2.1 --criteria "a|b|c" > /dev/null
+  bash "$LIB" --verify-criterion --task-id 2.1 --criterion-index 1 > /dev/null
+  assert_valid_json
+  run jq -c '[.tasks[] | select(.id=="2.1") | .acceptance_criteria[].verified]' .impl/manifest.json
+  [ "$output" = "[false,true,false]" ]
+  run jq -r '[.tasks[] | select(.id=="2.1") | .acceptance_criteria[1].verified_at]|first' .impl/manifest.json
+  [ "$output" != "null" ]
+}
+
+@test "an out-of-range criterion index is rejected" {
+  bash "$LIB" --add-task --task-id 2.1 --phase 2 --description "auth" > /dev/null
+  bash "$LIB" --set-criteria --task-id 2.1 --criteria "a|b" > /dev/null
+  run bash "$LIB" --verify-criterion --task-id 2.1 --criterion-index 9
+  [ "$status" -eq 1 ]
+}
+
+@test "setting criteria on an unknown task fails loudly" {
+  run bash "$LIB" --set-criteria --task-id nope --criteria "a"
+  [ "$status" -eq 1 ]
+}
+
+@test "criteria do not disturb other tasks" {
+  bash "$LIB" --add-task --task-id 2.1 --phase 2 --description "auth" > /dev/null
+  bash "$LIB" --add-task --task-id 2.2 --phase 2 --description "other" > /dev/null
+  bash "$LIB" --set-criteria --task-id 2.1 --criteria "a|b" > /dev/null
+  assert_valid_json
+  run jq -r '[.tasks[] | select(.id=="2.2") | .acceptance_criteria // "none"] | first' .impl/manifest.json
+  [ "$output" = "none" ]
+}
+
+@test "a task without criteria lists nothing rather than failing" {
+  bash "$LIB" --add-task --task-id 2.1 --phase 2 --description "auth" > /dev/null
+  run bash "$LIB" --list-criteria --task-id 2.1
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# --- Portability regressions (the `sed -i` bug) ---
+
+@test "a second task can be added without jq" {
+  nojq --add-task --task-id 1.1 --phase 1 --description "first" > /dev/null
+  run nojq --add-task --task-id 1.2 --phase 1 --description "second"
+  [ "$status" -eq 0 ]
+  assert_valid_json
+  run jq -r '.tasks | length' .impl/manifest.json
+  [ "$output" = "2" ]
+}
+
+@test "status updates work without jq and touch only the target task" {
+  nojq --add-task --task-id 1.1 --phase 1 --description "first" > /dev/null
+  nojq --add-task --task-id 1.2 --phase 1 --description "second" > /dev/null
+  run nojq --update-status --task-id 1.1 --status merged --branch impl/x
+  [ "$status" -eq 0 ]
+  assert_valid_json
+  run jq -r '[.tasks[] | select(.id=="1.1") | .status] | first' .impl/manifest.json
+  [ "$output" = "merged" ]
+  run jq -r '[.tasks[] | select(.id=="1.2") | .status] | first' .impl/manifest.json
+  [ "$output" = "pending" ]
+}
+
+# --- Without jq ---
+
+@test "checkpoint round-trips without jq" {
+  run nojq --set-checkpoint --session-id sess-x --agent-id impl-worker --phase 3 \
+    --summary-text 'phase 2 done; task-3a blocked on review'
+  [ "$status" -eq 0 ]
+  assert_valid_json
+  run nojq --get-checkpoint
+  echo "$output" | grep -q 'task-3a blocked on review'
+  echo "$output" | grep -q 'session_id=sess-x'
+}
+
+@test "overwriting a checkpoint without jq leaves exactly one" {
+  nojq --set-checkpoint --summary-text "first" > /dev/null
+  nojq --set-checkpoint --summary-text "second" > /dev/null
+  assert_valid_json
+  [ "$(grep -c '"checkpoint"' .impl/manifest.json)" -eq 1 ]
+  run jq -r '.checkpoint.orchestrator_summary' .impl/manifest.json
+  [ "$output" = "second" ]
+}
+
+@test "clearing a checkpoint without jq leaves the manifest valid" {
+  nojq --set-checkpoint --summary-text "s" > /dev/null
+  run nojq --clear-checkpoint
+  [ "$status" -eq 0 ]
+  assert_valid_json
+  run jq 'has("checkpoint")' .impl/manifest.json
+  [ "$output" = "false" ]
+}
+
+@test "criteria round-trip without jq" {
+  nojq --add-task --task-id 2.1 --phase 2 --description "auth" > /dev/null
+  run nojq --set-criteria --task-id 2.1 --criteria "rejects 401|passes valid"
+  [ "$status" -eq 0 ]
+  assert_valid_json
+  run nojq --verify-criterion --task-id 2.1 --criterion-index 0
+  [ "$status" -eq 0 ]
+  assert_valid_json
+  run nojq --list-criteria --task-id 2.1
+  echo "$output" | grep -q '^0|verified|rejects 401'
+  echo "$output" | grep -q '^1|pending|passes valid'
+}
+
+@test "a checkpoint written without jq is readable with jq, and vice versa" {
+  nojq --set-checkpoint --session-id sess-x --summary-text 'written without jq' > /dev/null
+  run bash "$LIB" --get-checkpoint
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'written without jq'
+
+  bash "$LIB" --set-checkpoint --session-id sess-y --summary-text 'written with jq' > /dev/null
+  run nojq --get-checkpoint
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'written with jq'
+}


### PR DESCRIPTION
Implements [RFC-011](docs/proposals/011-agent-memory-and-resumability.md), accepted here with its four open questions resolved.

## Resolved questions

| Question | Answer |
|---|---|
| Memory pruning | Soft byte budget (8 KB warn / 16 KB louder), advisory only. **Injection never truncates** |
| Forks | Knowledge transfers; metrics reset by explicit command, since fork detection is unreliable |
| principled-tasks correlation | `/resume` reports divergence and reconciles nothing |
| New plugin? | Yes — the three memory-bearing agents live in three plugins that can't reference each other |

## What's here

**`principled-agent`** (eighth plugin) — state about the *worker*: `.agents/` registry and memory, `lib/agent-memory.sh`, 4 skills, and 2 hooks (injection on `SubagentStart`, integrity advisory on writes).

**`principled-implementation`** — state about the *work*: a manifest `checkpoint`, per-task `acceptance_criteria`, and `/resume`. Both fields are additive and optional; existing manifests are untouched and still valid.

**ADR-020** makes memory a revisable frontmatter document rather than an event log — deliberately diverging from ADR-017, because a wrong learned pattern that *cannot be deleted* compounds on every spawn. **ADR-021** keeps Plan → Phase → Task intact and makes the checkpoint advisory, since a summary written by a failing session can describe a state that never held.

## Bug fixed in passing

Five `sed -i` calls in `task-manifest.sh`'s no-jq fallback. BSD sed reads the following argument as a backup suffix, so on stock macOS **adding a second task and every status update failed outright**. This repo commits to bash 3.2 + optional jq, so that path was broken for anyone without jq on macOS. Replaced with awk; pinned by regression tests.

## Design note worth reviewing

Memory injection **never truncates**. An agent handed a silently halved memory file has a confidently incomplete picture and no way to notice, so oversized memory is *reported* by the integrity hook rather than trimmed on the way in. Only agents the registry marks `memory: true` receive anything at all — deterministic auditors learn nothing, so injecting into them spends context for no benefit.

## Verification

`just ci` green — **126 bats tests, up from 62**. Every new operation is exercised both with jq and with a PATH that genuinely lacks it (trimming to `/usr/bin:/bin` doesn't work — jq lives in `/usr/bin` on macOS), with results validated by the real jq afterward.

Not machine-tested, and not claimed to be: `/resume`, `/agent-init`, `/agent-memory`, `/agent-retro` are skill prose, model-executed. Their script dependencies are covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKzFURKGfB1Ec3ayH2hjE2