### PR TITLE
feat: GitHub-native agent collaboration (RFC-012, Plan-011)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -35,6 +35,7 @@ Every plugin now uses the `lib/` pattern (ADR-018) — one copy, no propagation:
 - `plugins/principled-implementation/lib/templates/claude-task.md`
 - `plugins/principled-tasks/lib/task-db.sh`
 - `plugins/principled-agent/lib/agent-memory.sh`
+- `plugins/principled-agent/lib/agent-governance.sh`
 
 Edit in place. Skills reference them as `${CLAUDE_PLUGIN_ROOT}/lib/<name>`.
 
@@ -50,12 +51,13 @@ Edit in place. Skills reference them as `${CLAUDE_PLUGIN_ROOT}/lib/<name>`.
 ### Modifying `check-gh-cli.sh` (cross-plugin)
 
 This is the only script still duplicated across plugins. principled-github,
-principled-quality and principled-release install independently, so
+principled-quality, principled-release and principled-agent install independently, so
 `${CLAUDE_PLUGIN_ROOT}` cannot reach across the boundary and each needs its own copy.
-Three copies, down from fifteen.
+Four copies, down from fifteen.
 
 - **Canonical:** `plugins/principled-github/lib/check-gh-cli.sh`
-- Propagate to `plugins/principled-quality/lib/` and `plugins/principled-release/lib/`
+- Propagate to `plugins/principled-quality/lib/`, `plugins/principled-release/lib/`
+  and `plugins/principled-agent/lib/`
   (or run `/propagate-templates`).
 - Verify with `bash scripts/check-cross-plugin-drift.sh`.
 - Forgetting to propagate = CI failure.
@@ -94,6 +96,22 @@ ADR-018.
 - **Never make injection truncate.** An agent handed a silently halved memory file has a
   confidently incomplete picture and no way to notice. Oversized memory is reported by
   the integrity hook; it is never trimmed on the way in.
+
+### Editing Governance Code (principled-agent)
+
+- `agent-governance.sh` uses **exit 3 for a refusal** and exit 1 for an error. Never
+  collapse them: a caller that conflates them either ignores a real refusal or halts on
+  a transient fault.
+- **Unknown budgets must fail closed.** When `gh` is unavailable the counts are unknown,
+  and dispatch refuses. Treating unknown as zero would silently disable the safety layer
+  exactly when the environment is already misbehaving. `tests/agent-governance.bats`
+  asserts that `--status` never prints `0/5` for an unknown count.
+- The halt switch is a **file path contract** (`.agents/HALT`) shared with
+  principled-implementation. Plugins cannot call each other (ADR-018), so this coupling
+  is invisible to `check-skill-references.sh` and must be maintained by convention. If
+  the path changes, `/orchestrate` must change with it.
+- The dispatch workflow is a **template**, not an active workflow. Do not add it to
+  `.github/workflows/` in this repository (ADR-023).
 
 ### Editing the Manifest Schema (principled-implementation)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ Eleven layers, top to bottom:
 | `task-audit`    | `/task-audit [--all]`                                       | Analytical |
 | `task-graph`    | `/task-graph [--format dot\|text] [--status <status>]`      | Analytical |
 
-### principled-agent (4 skills)
+### principled-agent (7 skills)
 
 | Skill            | Command                                             | Category   |
 | ---------------- | --------------------------------------------------- | ---------- |
@@ -169,7 +169,7 @@ drift checker — drift is impossible rather than detected.
 | principled-release        | `check-gh-cli.sh` (vendored), `collect-changes.sh`, `check-readiness.sh`, `detect-modules.sh` |
 | principled-architecture   | `scan-modules.sh`                                                                             |
 | principled-tasks          | `task-db.sh`                                                                                  |
-| principled-agent          | `agent-memory.sh`                                                                             |
+| principled-agent          | `agent-memory.sh`, `agent-governance.sh`, `check-gh-cli.sh` (vendored)                        |
 
 `scripts/check-skill-references.sh` verifies every referenced path resolves **and**
 that it uses `${CLAUDE_PLUGIN_ROOT}`. Both halves matter. The old drift checkers
@@ -186,10 +186,11 @@ Two cases remain, both deliberate:
   `skills/scaffold/templates/{core,lib,app}/`; each generative skill ships the
   template it writes. Verified by
   `plugins/principled-docs/skills/scaffold/scripts/check-template-drift.sh`.
-- **`check-gh-cli.sh` across three plugins.** principled-github, principled-quality
-  and principled-release install independently, and `${CLAUDE_PLUGIN_ROOT}` resolves
-  to one plugin, so a genuinely shared script must exist three times. Fifteen copies
-  became three. Verified by `scripts/check-cross-plugin-drift.sh`.
+- **`check-gh-cli.sh` across four plugins.** principled-github, principled-quality,
+  principled-release and principled-agent install independently, and
+  `${CLAUDE_PLUGIN_ROOT}` resolves to one plugin, so a genuinely shared script must
+  exist four times. Fifteen copies became four. Verified by
+  `scripts/check-cross-plugin-drift.sh`.
 
 When updating either, edit the canonical version first, then propagate.
 
@@ -242,9 +243,12 @@ This repo uses its own documentation pipeline at the root level (governing the m
   - 019: Bats for shell testing
   - 020: Agent memory as a frontmatter document (not an event log)
   - 021: Manifest checkpoint and criterion-level acceptance tracking
+  - 022: Agent governance constraints for autonomous execution
+  - 023: GitHub Actions as the first dispatch backend, shipped opt-in
 - `docs/architecture/` — Living design docs.
   - plugin-system.md, documentation-pipeline.md, enforcement-system.md,
-    architecture-governance.md, release-system.md, agent-memory.md
+    architecture-governance.md, release-system.md, agent-memory.md,
+    agent-collaboration.md
 
 ## Versioning
 
@@ -278,13 +282,13 @@ See `CONTRIBUTING.md` for the full contributor guide. Key points:
 This repo installs all eight first-party plugins (via `.claude/settings.json`):
 
 - **principled-docs** — All 9 skills, 8 enforcement hooks, and 2 agents are active during development.
-- **principled-implementation** — All 7 skills, the `impl-worker` agent, and 5 hooks (1 advisory + 4 lifecycle) are active during development. Agent teams available when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`.
+- **principled-implementation** — All 7 skills (including `/orchestrate --mode`), the `impl-worker` agent, and 5 hooks (1 advisory + 4 lifecycle) are active during development. Agent teams available when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`.
 - **principled-github** — All 9 skills, 1 advisory hook, and the `issue-ingester` agent are active during development.
 - **principled-quality** — All 5 skills, 1 advisory hook, and the `pr-reviewer` agent are active during development.
 - **principled-release** — All 6 skills and 1 advisory hook are active during development.
 - **principled-architecture** — All 6 skills, 1 advisory hook, and the `boundary-checker` agent are active during development.
 - **principled-tasks** — All 7 skills and 1 advisory hook are active during development. Shared code lives in `lib/task-db.sh` (ADR-018).
-- **principled-agent** — All 4 skills and 2 hooks (memory injection + integrity advisory) are active during development. Shared code lives in `lib/agent-memory.sh` (ADR-018).
+- **principled-agent** — All 7 skills and 3 hooks are active during development. Shared code lives in `lib/agent-memory.sh` and `lib/agent-governance.sh` (ADR-018). The dispatch workflow is **not** installed: it ships as an opt-in template (ADR-023).
 
 See `.claude/CLAUDE.md` for development-specific context.
 
@@ -406,12 +410,17 @@ Declared in `plugins/principled-agent/hooks/hooks.json`:
 | ------------------------- | ------------------------- | ------------------------------------------------------------------ | ------- |
 | Agent Memory Injection    | SubagentStart             | `plugins/principled-agent/hooks/scripts/inject-agent-memory.sh`    | 10s     |
 | Memory Integrity Advisory | PostToolUse (Edit\|Write) | `plugins/principled-agent/hooks/scripts/check-memory-integrity.sh` | 10s     |
+| Governance Advisory       | PostToolUse (Bash)        | `plugins/principled-agent/hooks/scripts/check-agent-governance.sh` | 10s     |
 
 - Agent Memory Injection: emits global and per-agent memory to stderr at spawn. Only
   agents the registry marks `memory: true` receive anything. Never truncates, always
   exits 0 — a memory problem must not stop an agent running.
 - Memory Integrity Advisory: validates frontmatter and reports against the 8 KB / 16 KB
   context budget on writes under `.agents/`. Always exits 0.
+- Governance Advisory: warns on non-draft agent PRs, self-approval, merge, and
+  ready-for-review promotion, and surfaces an engaged halt switch on dispatch commands.
+  Always exits 0 — PostToolUse fires after the command has run, so the authoritative
+  gate is `agent-governance.sh --can-dispatch` before a run starts (ADR-022).
 
 ## Testing
 
@@ -419,7 +428,7 @@ Declared in `plugins/principled-agent/hooks/hooks.json`:
 - **Cross-plugin drift:** `scripts/check-cross-plugin-drift.sh` — exits non-zero if a vendored `check-gh-cli.sh` diverges from canonical.
 - **Pipeline audit:** `scripts/pipeline-audit.sh` — reconciles declared document state against the repository (numbering, plan/proposal links, statuses, supersession chains).
 - **Reference integrity:** `scripts/check-skill-references.sh` — exits non-zero if any script or template referenced by a SKILL.md or hooks.json does not exist.
-- **Tests:** `npx bats tests/` — bats suite covering the task graph library, agent memory, the manifest checkpoint and criteria, and every hook. Also run on macOS bash 3.2 in CI.
+- **Tests:** `npx bats tests/` — bats suite covering the task graph library, agent memory, agent governance, the manifest checkpoint and criteria, and every hook. Also run on macOS bash 3.2 in CI.
 - **Structure validation:** `plugins/principled-docs/lib/validate-structure.sh --module-path <path> [--type <type>] [--strict] [--json]` — checks a module's docs structure.
 - **Root validation:** `plugins/principled-docs/lib/validate-structure.sh --root` — checks repo-level docs structure.
 - **Hook testing (docs):** Feed JSON with `tool_input.file_path` to guard scripts via stdin. Exit 0 = allow, exit 2 = block.
@@ -430,7 +439,7 @@ Declared in `plugins/principled-agent/hooks/hooks.json`:
 - **Hook testing (architecture):** Feed JSON with `tool_input.file_path` to `check-boundary-violation.sh` via stdin. Always exits 0 (advisory).
 - **Hook testing (tasks):** Feed JSON with `tool_input.file_path` to `check-db-integrity.sh` via stdin. Always exits 0 (advisory).
 - **Hook testing (agent):** Feed JSON with an agent id to `inject-agent-memory.sh`, or `tool_input.file_path` to `check-memory-integrity.sh`, via stdin. Both always exit 0.
-- **Hook testing (all):** `npx bats tests/hooks.bats` — 48 tests covering allow, block, malformed input, and the no-jq fallback path for every hook.
+- **Hook testing (all):** `npx bats tests/hooks.bats` — 57 tests covering allow, block, malformed input, and the no-jq fallback path for every hook.
 - **Shell lint:** `shellcheck --shell=bash` and `shfmt -i 2 -bn -sr -d` on all `.sh` files.
 - **Markdown lint:** `npx markdownlint-cli2 '**/*.md'` and `npx prettier --check '**/*.md'`.
 - **Marketplace validation:** Verify `.claude-plugin/marketplace.json` is valid and all plugin source directories exist.

--- a/README.md
+++ b/README.md
@@ -20,16 +20,16 @@ A Claude Code plugin marketplace hosting first-party and community plugins for t
 
 ### First-Party
 
-| Plugin                                                                       | Category       | Description                                                                                                                        |
-| ---------------------------------------------------------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| [**principled-docs**](plugins/principled-docs/README.md)                     | documentation  | Scaffold, author, and enforce module documentation structure following the Principled specification-first methodology (v0.3.1)     |
-| [**principled-implementation**](plugins/principled-implementation/README.md) | implementation | Orchestrate DDD plan execution via worktree-isolated Claude Code agents (v0.1.0)                                                   |
-| [**principled-github**](plugins/principled-github/README.md)                 | workflow       | Integrate the principled workflow with GitHub native features: issues, PRs, templates, actions, CODEOWNERS, and labels (v0.1.0)    |
-| [**principled-quality**](plugins/principled-quality/README.md)               | quality        | Connect code reviews to the principled documentation pipeline with spec-driven checklists and review tracking (v0.1.0)             |
-| [**principled-release**](plugins/principled-release/README.md)               | workflow       | Generate changelogs from the documentation pipeline, verify release readiness, and coordinate versioned releases (v0.1.0)          |
-| [**principled-architecture**](plugins/principled-architecture/README.md)     | architecture   | Map modules to governing ADRs, detect architectural drift, audit governance coverage, and sync architecture docs (v0.1.0)          |
-| [**principled-tasks**](plugins/principled-tasks/README.md)                   | workflow       | Git-native, graph-linked task tracking backed by an append-only event log — merges cleanly across parallel agent branches (v0.1.0) |
-| [**principled-agent**](plugins/principled-agent/README.md)                   | orchestration  | Persistent agent identity and memory — git-committed knowledge injected at spawn and revised in pull requests (v0.1.0)             |
+| Plugin                                                                       | Category       | Description                                                                                                                           |
+| ---------------------------------------------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| [**principled-docs**](plugins/principled-docs/README.md)                     | documentation  | Scaffold, author, and enforce module documentation structure following the Principled specification-first methodology (v0.3.1)        |
+| [**principled-implementation**](plugins/principled-implementation/README.md) | implementation | Orchestrate DDD plan execution via worktree-isolated Claude Code agents (v0.1.0)                                                      |
+| [**principled-github**](plugins/principled-github/README.md)                 | workflow       | Integrate the principled workflow with GitHub native features: issues, PRs, templates, actions, CODEOWNERS, and labels (v0.1.0)       |
+| [**principled-quality**](plugins/principled-quality/README.md)               | quality        | Connect code reviews to the principled documentation pipeline with spec-driven checklists and review tracking (v0.1.0)                |
+| [**principled-release**](plugins/principled-release/README.md)               | workflow       | Generate changelogs from the documentation pipeline, verify release readiness, and coordinate versioned releases (v0.1.0)             |
+| [**principled-architecture**](plugins/principled-architecture/README.md)     | architecture   | Map modules to governing ADRs, detect architectural drift, audit governance coverage, and sync architecture docs (v0.1.0)             |
+| [**principled-tasks**](plugins/principled-tasks/README.md)                   | workflow       | Git-native, graph-linked task tracking backed by an append-only event log — merges cleanly across parallel agent branches (v0.1.0)    |
+| [**principled-agent**](plugins/principled-agent/README.md)                   | orchestration  | Agent identity, memory, and the contributor protocol — governed dispatch, draft-PR constraints, and a file-based halt switch (v0.1.0) |
 
 ### Community
 

--- a/docs/architecture/agent-collaboration.md
+++ b/docs/architecture/agent-collaboration.md
@@ -1,0 +1,181 @@
+---
+title: "Agent Collaboration and Autonomous Execution"
+last_updated: 2026-07-28
+related_adrs: [022, 023, 010, 016, 021]
+---
+
+# Agent Collaboration and Autonomous Execution
+
+## Purpose
+
+Describes the Agent Contributor Protocol, the governance constraints that make it safe to
+run unattended, and how dispatch reaches an agent. Intended for anyone enabling
+autonomous execution, reviewing agent-authored PRs, or assessing the governance risk of
+letting agents open PRs against a repository.
+
+## The protocol
+
+```
+ 1. Issue labelled agent-ready, assigned to an agent
+ 2. Agent picks it up            /agent-dispatch <issue>
+ 3. Agent drafts a proposal      /new-proposal
+ 4. ── HUMAN APPROVES ──────────────────────────────────
+ 5. Agent drafts a plan          /new-plan --from-proposal NNN
+ 6. ── HUMAN APPROVES ──────────────────────────────────
+ 7. Agent executes               /orchestrate --mode supervised|autonomous
+ 8. Agent self-reviews           /review-checklist
+ 9. Agent opens a DRAFT PR       /pr-describe
+10. ── HUMAN REVIEWS ───────────────────────────────────
+11. Agent addresses feedback     /agent-respond <pr>
+12. ── HUMAN MERGES ────────────────────────────────────
+```
+
+**The four human gates are the design, not overhead.** The agent does the work; a human
+owns every irreversible decision. Steps 3, 5, 8 and 11 are cheap to redo; steps 4, 6, 10
+and 12 are not.
+
+The protocol is a workflow pattern, not a platform. It runs identically with
+`/agent-dispatch --local` in a terminal and through CI.
+
+## Governance is mechanical, not documentary
+
+The modes exist for the case where nobody is watching. "The agent should check" is
+unfalsifiable exactly then, so each constraint that matters is enforced by something a
+script can answer (ADR-022).
+
+| Constraint             | Mechanism                         | Where                       |
+| ---------------------- | --------------------------------- | --------------------------- |
+| Halt switch            | `.agents/HALT` exists             | Before dispatch; phase ends |
+| Blocker budget         | open `agent-blocked` issues < 5   | `--can-dispatch`            |
+| Review-capacity budget | open `agent-authored` PRs < 5     | `--can-dispatch`            |
+| Retry budget           | task retries ≤ 2                  | Orchestration loop          |
+| Phase circuit breaker  | phase failure rate ≤ 50%          | Phase boundary              |
+| Draft PRs, no approval | advisory hook + branch protection | `check-agent-governance.sh` |
+
+### The gate
+
+```
+/agent-dispatch
+  └─ agent-governance.sh --can-dispatch
+       ├─ .agents/HALT exists?        → exit 3, refuse (checked first: no network needed)
+       ├─ counts unavailable?         → exit 3, refuse — unknown is NOT headroom
+       ├─ agent-blocked  >= budget?   → exit 3, refuse
+       ├─ agent-authored >= budget?   → exit 3, refuse
+       └─ otherwise                   → exit 0, proceed
+```
+
+**Exit 3 means refused; exit 1 means could not tell.** The distinction is load-bearing: a
+caller that conflates them either ignores a real refusal or halts on a transient fault.
+
+**Unknown budgets fail closed.** When `gh` is unavailable the counts are unknown, and
+dispatch refuses rather than assuming room. Treating unknown as zero would silently
+disable the safety layer at exactly the moment the environment is already misbehaving.
+
+### The halt switch
+
+A committed file at `.agents/HALT`, whose contents are a reason string.
+
+File-based rather than a GitHub label because it behaves identically under `--local` and
+CI, needs no API call (so it works when the API is what is broken), and is operable by
+anyone with repository write access and no running session — which is the point, since
+whoever needs to stop a runaway is rarely whoever started it.
+
+Checked before every dispatch and at every **phase boundary**, never mid-task:
+interrupting a worker halfway leaves a worktree in an unknown state, and the phase
+boundary is the nearest point where stopping is clean.
+
+It is also the seam between two plugins that cannot call each other. principled-agent
+owns the switch; principled-implementation only reads the path. Plugins install
+independently and cannot reference each other's `${CLAUDE_PLUGIN_ROOT}` (ADR-018), so
+**the file path is the contract** — a coupling invisible to the reference checker and
+maintained by convention.
+
+## Two orthogonal axes
+
+Conflating these causes real confusion, because both get called "mode".
+
+| Axis            | Selected by                            | Answers                               |
+| --------------- | -------------------------------------- | ------------------------------------- |
+| **Parallelism** | `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` | How many tasks run at once?           |
+| **Autonomy**    | `--mode`                               | How much human involvement is needed? |
+
+They are independent: any autonomy level runs under either parallelism strategy.
+
+| `--mode`      | Behaviour                                 | Human involvement      |
+| ------------- | ----------------------------------------- | ---------------------- |
+| `interactive` | Unchanged from before RFC-012             | Continuous             |
+| `supervised`  | Runs on, pausing at decision points       | At decision gates      |
+| `autonomous`  | Runs end to end, posts results for review | Post-completion review |
+
+`--mode` defaults to `interactive`, so existing invocations behave exactly as before.
+
+## Dispatch
+
+```
+/agent-dispatch <issue>
+  ├─ --local  → run the protocol in this session   (no CI, no credentials)
+  └─ default  → gh workflow run agent-dispatch.yml (opt-in template)
+```
+
+**The skill is the abstraction boundary** (ADR-023). There is no runtime interface or
+backend registry, because there is exactly one backend and a second does not exist to
+generalize from. A future backend changes one branch of one skill.
+
+`--local` is what makes the portability claim honest: it is not a degraded fallback, it
+is the primary way to use the protocol with no infrastructure at all.
+
+### The workflow is opt-in
+
+`agent-dispatch.yml` ships as a **template** and is deliberately not active in this
+repository. Installing a plugin should not arm anything, and the gap between "I installed
+a documentation plugin" and "agents now open PRs on a label" is where unpleasant
+surprises live.
+
+When installed it defaults to `workflow_dispatch` only; the `issues` trigger is present
+but commented, so enabling automatic dispatch is a visible, reviewable diff. Permissions
+are `contents`, `issues`, and `pull-requests` write — no `actions: write`, so a
+compromised run cannot rewrite its own dispatcher.
+
+## The feedback loop
+
+This is what stops a reviewer correcting the same thing forever:
+
+```
+Human reviews PR
+  └─ /agent-respond <pr>
+       ├─ defect     → fix, reply                    (a fact about one PR)
+       ├─ convention → fix, reply, PROMOTE TO MEMORY (a fact about the codebase)
+       └─ preference → judgement, reply either way
+                            │
+                            └─ .agents/memory/agents/<id>.md
+                                 └─ injected at the next spawn (ADR-020)
+```
+
+Only conventions are promoted. Promoting a defect writes an incident into memory, where
+it dilutes context forever without preventing anything.
+
+## Known limits
+
+- **Review fatigue is the real ceiling.** CI minutes and API quota are elastic; reviewer
+  attention is not. If agents open PRs faster than humans read them, the gate becomes a
+  rubber stamp — which is worse than no gate, because it looks like oversight. The
+  in-flight cap exists for this and is the number most likely to need tuning.
+- **The caps are not measured.** 5, 5, 3 and 2 are conservative defaults. This repository
+  has never run autonomous dispatch, and any number presented as measured would be
+  invented. Raise them from observation: a draining PR queue means headroom, accumulating
+  blockers mean none.
+- **The template is not exercised by CI.** The reference checker confirms it exists, not
+  that it runs, so it can rot undetected.
+- **The four-role parallel model needs agent teams** (ADR-016, still `proposed`). Roles
+  are documented as a coordination pattern over shipped skills; no code requires teams.
+- **A stale `.agents/HALT` blocks everything.** Every refusal prints the reason and the
+  path, so the cause is never a mystery — but nothing expires it.
+
+## Related
+
+- [ADR-022: Agent Governance Constraints](../decisions/022-agent-governance-constraints.md)
+- [ADR-023: GitHub Actions as the First Dispatch Backend](../decisions/023-github-actions-dispatch-backend.md)
+- [ADR-021: Manifest Checkpoint and Criterion-Level Acceptance](../decisions/021-manifest-checkpoint-schema.md)
+- [ADR-010: gh CLI as GitHub Interface](../decisions/010-gh-cli-as-github-interface.md)
+- [Agent Memory and Resumability](agent-memory.md)
+- [RFC-012](../proposals/012-github-native-agent-collaboration.md) / [Plan-011](../plans/011-github-native-agent-collaboration.md)

--- a/docs/architecture/plugin-system.md
+++ b/docs/architecture/plugin-system.md
@@ -179,8 +179,30 @@ PostToolUse hook fires (after execution)
 
 ## Constraints and Invariants
 
-1. **Skills are self-contained.** Every skill directory contains everything it needs. No cross-skill imports or shared directories.
-2. **Template copies are byte-identical.** The drift checker enforces this. Drift is a CI failure.
-3. **Hooks and skills never overlap.** Skills handle generative workflows. Hooks handle deterministic guardrails.
-4. **Scripts have no shared directory.** If a utility is needed in multiple places, each location maintains its own copy, validated by drift checks.
-5. **Marketplace root contains only infrastructure.** `.claude-plugin/marketplace.json`, `plugins/`, `external_plugins/`, `docs/`, `README.md`. Individual plugins are self-contained under `plugins/`.
+1. **Skills own their prompts and templates.** A skill directory contains what only that skill uses. No cross-skill imports, and no `../sibling/` paths.
+2. **Code used by more than one skill lives in the plugin's `lib/`**, referenced as `${CLAUDE_PLUGIN_ROOT}/lib/<name>` ([ADR-018](../decisions/018-shared-plugin-lib-over-copies.md)). One copy, so drift is impossible rather than detected. This supersedes ADR-009's copy-with-drift-detection scheme.
+3. **Plugins cannot reference each other.** Each installs independently and `${CLAUDE_PLUGIN_ROOT}` resolves to exactly one plugin, so a genuinely cross-plugin script must be vendored — the only remaining case is `check-gh-cli.sh`, in four copies, verified by `scripts/check-cross-plugin-drift.sh`.
+4. **Template copies are byte-identical.** The drift checker enforces this for the scaffolding templates. Drift is a CI failure.
+5. **Hooks and skills never overlap.** Skills handle generative workflows. Hooks handle deterministic guardrails.
+6. **Marketplace root contains only infrastructure.** `.claude-plugin/marketplace.json`, `plugins/`, `external_plugins/`, `docs/`, `README.md`. Individual plugins are self-contained under `plugins/`.
+
+## Cross-plugin coupling: the file-path contract
+
+Constraint 3 means two plugins that must cooperate cannot call each other. Where
+cooperation is genuinely required, the coupling is a **committed file at a fixed
+repository-root path**, which both read independently:
+
+| Path                      | Written by                | Read by                                       |
+| ------------------------- | ------------------------- | --------------------------------------------- |
+| `.agents/`                | principled-agent          | any plugin; injected at spawn (ADR-020)       |
+| `.agents/HALT`            | principled-agent          | principled-implementation at phase boundaries |
+| `.impl/manifest.json`     | principled-implementation | principled-agent, read-only (ADR-021)         |
+| `.principled/tasks.jsonl` | principled-tasks          | any plugin, read-only (ADR-017)               |
+
+This is the only mechanism available, and for the halt switch it is also the right one:
+the switch must be operable by a human with no running session (ADR-022).
+
+The cost is real — **these couplings are invisible to `check-skill-references.sh`**,
+which validates `${CLAUDE_PLUGIN_ROOT}` paths and cannot see a bare path in prose. They
+are maintained by convention, so changing one of these paths means finding every reader
+by hand.

--- a/docs/decisions/022-agent-governance-constraints.md
+++ b/docs/decisions/022-agent-governance-constraints.md
@@ -1,0 +1,172 @@
+---
+title: "Agent Governance Constraints for Autonomous Execution"
+number: "022"
+status: accepted
+author: Alex
+created: 2026-07-28
+updated: 2026-07-28
+originating_proposal: "012"
+supersedes: null
+superseded_by: null
+---
+
+# ADR-022: Agent Governance Constraints for Autonomous Execution
+
+## Status
+
+Accepted
+
+<!-- Valid values: proposed, accepted, deprecated, superseded -->
+<!-- Once accepted, this document is IMMUTABLE. -->
+<!-- Exception: superseded_by may be updated when a new ADR supersedes this one. -->
+
+## Context
+
+RFC-012 lets agents run without a human present: pick up a labelled issue, execute a
+plan, open a PR. That is a material change in blast radius. Today a human starts every
+run and watches it; afterwards, an unattended run can produce many PRs before anyone
+looks.
+
+The temptation is to treat governance as documentation — a protocol in a markdown file
+that agents are told to follow. RFC-012's own risk register names why that fails:
+**agents may skip steps under `autonomous` mode if the protocol is only prose.** A
+non-deterministic system asked to police itself will sometimes not.
+
+So the question is not whether to have constraints, but which ones are load-bearing
+enough to enforce mechanically, and where the enforcement lives.
+
+### What makes this different from the existing hooks
+
+The pipeline's existing guards protect _documents_ from _edits_ — an accepted ADR must
+not change. These constraints protect a _repository_ from a _process_ that is running
+unattended and may be malfunctioning. The failure they guard against is not one bad
+write; it is a loop that produces bad writes faster than anyone reads them.
+
+## Decision
+
+**Six constraints, each enforced by a mechanism rather than by instruction.**
+
+### 1. A file-based halt switch
+
+`.agents/HALT` stops all dispatch and pauses orchestration at the next phase boundary.
+Any file content is treated as a reason string and surfaced when a run refuses to start.
+
+File-based rather than a GitHub label because it works identically under `--local` and
+under CI (one mechanism, not two that can disagree), needs no API call (so it works when
+the API is what is broken), and is operable by anyone with repository write access and no
+running session — which is the point, since whoever needs to stop a runaway is usually
+not whoever started it.
+
+Checked before every dispatch and at every phase boundary. **Not** checked mid-task:
+interrupting a worker halfway leaves a worktree in an unknown state, and the phase
+boundary is the nearest point where stopping is clean.
+
+### 2. Agents open draft PRs and cannot approve them
+
+Promotion to ready-for-review is a human act. An agent that can approve or merge its own
+work removes the only reliable check on a non-deterministic system.
+
+### 3. Circuit breakers, not retries
+
+Three conditions halt a run rather than escalating it:
+
+| Condition                   | Default | Rationale                                       |
+| --------------------------- | ------- | ----------------------------------------------- |
+| Task retry budget exceeded  | 2       | A third identical attempt is not a strategy     |
+| Phase task-failure rate     | 50%     | Systemic fault, not one hard task               |
+| Open `agent-blocked` issues | 5       | Blockers outpacing triage means something broke |
+
+Each says the same thing: the evidence indicates the next attempt fails the same way, so
+stop and surface it. Halting is cheap and reversible; an accumulated mess is neither.
+
+### 4. In-flight PR cap over worker parallelism
+
+Default 5 in-flight agent PRs, and a default of 3 parallel workers.
+
+CI minutes and API quota are elastic — money and backoff raise them. **Human review
+capacity is not.** Review fatigue is worse than no gate, because a rubber stamp looks
+like oversight while providing none. The binding constraint is the reviewer, so the cap
+belongs on PRs awaiting review rather than on workers.
+
+Both numbers are conservative defaults, not measurements. This repository has never run
+autonomous dispatch, and a number presented as measured would be invented.
+
+### 5. Attribution on every agent commit
+
+Co-authorship trailers, and every agent PR links its issue, proposal, and plan. Without
+this an audit cannot distinguish agent work from human work after the fact, which is
+exactly what a reviewer needs to know when deciding how hard to look.
+
+### 6. No credentials in this repository's CI by default
+
+The dispatch workflow ships as an **opt-in template**, not an active workflow. See
+ADR-023.
+
+## Options Considered
+
+### Option 1: Enforce mechanically at each boundary (chosen)
+
+Each constraint sits at the point where it can actually be checked: the halt file before
+dispatch and at phase boundaries, budgets in the orchestration loop, PR governance in the
+skill that opens the PR.
+
+Cost: the constraints are spread across two plugins, so there is no single file that
+states them all — which is what this ADR and `docs/architecture/agent-collaboration.md`
+exist to compensate for.
+
+### Option 2: Governance as documented protocol only
+
+Far less code, and it trusts the model to follow a clearly written process. Rejected on
+the proposal's own evidence: the modes exist precisely for the case where no human is
+watching, so "the agent should check" is unfalsifiable at the moment it matters most.
+
+### Option 3: A single gatekeeper hook that approves every agent action
+
+One enforcement point, easy to audit. Rejected: it would need to understand dispatch,
+orchestration, and PR state simultaneously, coupling the two plugins that ADR-018
+deliberately keeps independent — and a gate that must be consulted for everything becomes
+a gate that is worked around.
+
+### Option 4: Rely on GitHub branch protection alone
+
+Protected branches and required reviews already prevent an unreviewed merge, at no cost.
+Rejected as insufficient rather than wrong: branch protection stops a bad _merge_, but
+nothing about it stops a runaway loop from opening ninety PRs, burning budget, and
+exhausting reviewers. It remains a required backstop, not the mechanism.
+
+## Consequences
+
+### Positive
+
+- A runaway loop is stoppable by someone with no access to the running session
+- Failure surfaces as a halt with a reason, rather than as volume
+- Review capacity is treated as the scarce resource it actually is
+- Agent work is attributable after the fact
+- Constraints hold under `autonomous` mode, where prose would not
+
+### Negative
+
+- More moving parts, and a halted run needs a human to understand _why_ before resuming
+- Conservative defaults will feel restrictive to anyone who has the review capacity to go
+  faster; they must be raised deliberately
+- The circuit breakers can stop a run that would have succeeded on the next attempt —
+  accepted, because the failure mode they prevent is much more expensive than one
+  unnecessary halt
+- Governance state lives in two plugins, coupled only by a file path. That coupling is
+  invisible to the reference checker and must be maintained by convention
+
+### Risks
+
+- **A stale `.agents/HALT` silently blocks all work.** Mitigation: every refusal prints
+  the file's reason string and its path, so the cause is never a mystery.
+- **Caps become the system's throughput and nobody revisits them.** Mitigation: they are
+  documented as unmeasured defaults with an explicit signal for raising them.
+
+## References
+
+- [RFC-012: GitHub-Native Agent Collaboration and Autonomous Execution](../proposals/012-github-native-agent-collaboration.md)
+- [ADR-023: GitHub Actions as the First Dispatch Backend](023-github-actions-dispatch-backend.md)
+- [ADR-020: Agent Memory as a Frontmatter Document](020-agent-memory-as-document.md)
+- [ADR-021: Manifest Checkpoint and Criterion-Level Acceptance](021-manifest-checkpoint-schema.md)
+- [ADR-010: gh CLI as GitHub Interface](010-gh-cli-as-github-interface.md)
+- [Plan-011: GitHub-Native Agent Collaboration](../plans/011-github-native-agent-collaboration.md)

--- a/docs/decisions/023-github-actions-dispatch-backend.md
+++ b/docs/decisions/023-github-actions-dispatch-backend.md
@@ -1,0 +1,159 @@
+---
+title: "GitHub Actions as the First Dispatch Backend, Shipped Opt-In"
+number: "023"
+status: accepted
+author: Alex
+created: 2026-07-28
+updated: 2026-07-28
+originating_proposal: "012"
+supersedes: null
+superseded_by: null
+---
+
+# ADR-023: GitHub Actions as the First Dispatch Backend, Shipped Opt-In
+
+## Status
+
+Accepted
+
+<!-- Valid values: proposed, accepted, deprecated, superseded -->
+<!-- Once accepted, this document is IMMUTABLE. -->
+<!-- Exception: superseded_by may be updated when a new ADR supersedes this one. -->
+
+## Context
+
+RFC-012 needs a way to start an agent session from an issue without a human running a
+command. GitHub Actions is the obvious first backend: the backlog is already GitHub
+issues (ADR-010 established `gh` as the GitHub interface), and Actions triggers on issue
+events for free.
+
+Two questions follow, and they are usually conflated.
+
+**Where is the abstraction boundary?** If dispatch is written directly against Actions,
+swapping backends later means rewriting the skill. If it is abstracted too early, the
+abstraction is invented rather than derived, and the second backend will not fit it
+anyway.
+
+**Should the workflow be active in this repository?** A workflow that triggers on
+`agent-ready` and runs a Claude Code session needs API credentials in CI and has
+repository write access. RFC-012 names credential exposure as a risk and notes that
+secrets management is a burden a repository plugin has not previously carried.
+
+That second question is easy to answer by default rather than deliberately — shipping a
+working `.github/workflows/agent-dispatch.yml` is the natural thing to do, and it is the
+wrong thing to do.
+
+## Decision
+
+**GitHub Actions is the first backend. The abstraction boundary is the `/agent-dispatch`
+skill. The workflow ships as an opt-in template, not as an active workflow.**
+
+### The boundary is the skill, not a runtime layer
+
+`/agent-dispatch <issue>` is the contract. It does two separable things:
+
+- `--local` runs the protocol in the current session. **No CI, no credentials, no
+  workflow file.** The entire infrastructure layer is optional.
+- Without `--local`, it triggers the configured backend, today a `workflow_dispatch` call
+  via `gh`.
+
+That is the whole abstraction. There is no runtime interface, no backend registry, no
+plugin seam — because there is exactly one backend, and a second one does not exist to
+generalize from. What the boundary buys is that a future backend changes one branch of
+one skill, and the protocol, governance, and every other skill are untouched.
+
+`--local` is what makes this honest rather than aspirational: the fallback path is not a
+degraded mode, it is the primary way to use the feature without adopting any
+infrastructure at all.
+
+### The workflow is a template
+
+The dispatch workflow lives at
+`plugins/principled-agent/skills/agent-dispatch/templates/agent-dispatch.yml` and is
+installed deliberately, the same way principled-github's `/gh-scaffold` installs CI
+templates.
+
+It is **not** committed to `.github/workflows/` in this repository, and when installed it
+defaults to `workflow_dispatch` only — manual trigger — with the `issues` trigger present
+but commented, so enabling automatic dispatch is a visible, reviewable edit.
+
+The template requests least-privilege permissions:
+
+```yaml
+permissions:
+  contents: write # branches and commits
+  issues: write # progress comments, agent-blocked
+  pull-requests: write # draft PRs
+```
+
+No `actions: write`, no `id-token`, no organization scope. The token cannot modify
+workflows, so a compromised run cannot rewrite its own dispatcher.
+
+### Why opt-in rather than active
+
+Installing a plugin should not arm anything. A user adding principled-agent for
+`/agent-memory` has not consented to a workflow that spends API credits on issue events,
+and the gap between "I installed a documentation plugin" and "agents now open PRs in my
+repository on a label" is exactly where unpleasant surprises live.
+
+The same reasoning applies to this repository. Dogfooding the _protocol_ is valuable;
+dogfooding _unattended dispatch with live credentials_ is a separate decision with a
+separate risk profile, and it should be made explicitly rather than inherited from a
+merge.
+
+## Options Considered
+
+### Option 1: Actions backend, skill-level boundary, opt-in template (chosen)
+
+Minimal abstraction for a single backend, and no capability is enabled without an
+explicit act.
+
+Cost: users who _want_ automatic dispatch have an extra installation step, and the
+template can drift from the skill that documents it.
+
+### Option 2: Ship an active workflow in `.github/workflows/`
+
+Immediately usable and genuinely dogfooded. Rejected: it requires credentials in CI
+before anyone has decided they want autonomous dispatch, and it makes plugin installation
+a security-relevant act. The convenience is small and the surprise is large.
+
+### Option 3: A backend abstraction layer with pluggable runtimes
+
+Clean seam for Actions, GitLab CI, a hosted runner. Rejected as premature — the interface
+would be derived from one implementation and would almost certainly be wrong for the
+second. `--local` plus a single skill already delivers the portability that matters.
+
+### Option 4: A long-lived agent service instead of CI
+
+Avoids cold starts and job time limits, and would support genuine parallelism. Rejected
+for now, matching RFC-012: it requires hosting, secrets management, and an availability
+story, none of which a repository plugin should own.
+
+## Consequences
+
+### Positive
+
+- Installing principled-agent arms nothing
+- The feature is fully usable with no CI at all, via `--local`
+- Least-privilege tokens; a compromised run cannot rewrite its dispatcher
+- Enabling automatic dispatch is one visible, reviewable diff
+- A future backend touches one branch of one skill
+
+### Negative
+
+- Automatic dispatch requires a manual install step, and users will hit that friction
+- The template is not exercised by this repository's CI, so it can rot undetected —
+  mitigated only by the reference checker confirming it exists, not that it runs
+- `workflow_dispatch`-by-default means the advertised "triggers on `agent-ready`"
+  behaviour requires an edit before it is true, which must be documented clearly or it
+  reads as a bug
+- Actions job time limits still cap how long one dispatched run can take, and nothing here
+  removes that
+
+## References
+
+- [RFC-012: GitHub-Native Agent Collaboration and Autonomous Execution](../proposals/012-github-native-agent-collaboration.md)
+- [ADR-022: Agent Governance Constraints for Autonomous Execution](022-agent-governance-constraints.md)
+- [ADR-010: gh CLI as GitHub Interface](010-gh-cli-as-github-interface.md)
+- [ADR-018: Shared Plugin lib/ Over Copies](018-shared-plugin-lib-over-copies.md)
+- [Plan-011: GitHub-Native Agent Collaboration](../plans/011-github-native-agent-collaboration.md)

--- a/docs/plans/011-github-native-agent-collaboration.md
+++ b/docs/plans/011-github-native-agent-collaboration.md
@@ -1,0 +1,177 @@
+---
+title: "GitHub-Native Agent Collaboration"
+number: "011"
+status: complete
+author: Alex
+created: 2026-07-28
+updated: 2026-07-28
+originating_proposal: "012"
+related_adrs: ["022", "023"]
+---
+
+# Plan-011: GitHub-Native Agent Collaboration
+
+## Objective
+
+Implements [RFC-012](../proposals/012-github-native-agent-collaboration.md).
+
+Deliver the Agent Contributor Protocol with its governance constraints enforced
+mechanically, execution modes on `/orchestrate`, three workforce skills in
+principled-agent, and GitHub Actions dispatch as an opt-in template.
+
+The organizing principle is ADR-022's: every constraint that matters is enforced by a
+mechanism, not by instructions an unattended agent may skip.
+
+## Related Decisions
+
+- [ADR-022: Agent Governance Constraints](../decisions/022-agent-governance-constraints.md) —
+  halt switch, draft PRs, circuit breakers, in-flight caps, attribution
+- [ADR-023: GitHub Actions as the First Dispatch Backend](../decisions/023-github-actions-dispatch-backend.md) —
+  skill-level boundary, opt-in template, least privilege
+- [ADR-020](../decisions/020-agent-memory-as-document.md) / [ADR-021](../decisions/021-manifest-checkpoint-schema.md) —
+  memory and checkpoint, delivered in Plan-010
+- [ADR-010: gh CLI as GitHub Interface](../decisions/010-gh-cli-as-github-interface.md)
+- [ADR-018: Shared Plugin lib/ Over Copies](../decisions/018-shared-plugin-lib-over-copies.md)
+
+## Domain Analysis
+
+### Bounded Contexts
+
+**Agent Workforce** (`principled-agent`) — who is working, on what, and whether they are
+allowed to start. Owns `.agents/HALT`, dispatch, review-feedback capture, and workforce
+reporting.
+
+**Execution Modes** (`principled-implementation`) — how much human involvement one
+orchestration run requires. Owns `--mode`, retry budgets, and the phase-failure breaker.
+
+**GitHub Surface** (`principled-github`, existing) — issues, PRs, labels. Read and
+written through `gh` (ADR-010); unchanged by this plan except for new labels.
+
+The seam between the first two is a **file path, not an API**: `.agents/HALT`. Plugins
+install independently and cannot reference each other's `${CLAUDE_PLUGIN_ROOT}`, and the
+halt switch must be operable by a human with no session, so a committed file is both the
+only available coupling and the correct one.
+
+### Aggregates
+
+| Aggregate       | Root                        | Invariants                                                      |
+| --------------- | --------------------------- | --------------------------------------------------------------- |
+| Halt state      | `.agents/HALT`              | Presence halts; content is a reason string, surfaced on refusal |
+| Dispatch budget | open `agent-blocked` issues | At or above 5, dispatch refuses                                 |
+| Review queue    | open agent-authored PRs     | At or above 5 in flight, dispatch refuses                       |
+| Run mode        | `.impl/manifest.json`       | Mode is a property of a run; absent means `interactive`         |
+
+### Domain Events
+
+- **DispatchRequested** → halt, blocked-issue, and PR-cap checks run before anything else
+- **PhaseBoundaryReached** → halt re-checked; supervised mode reports and continues
+- **RetryBudgetExceeded** → run halts, `agent-blocked` filed with diagnostics
+- **PhaseFailureRateExceeded** → run halts as systemic rather than retrying
+- **ReviewSubmitted** → comments captured and written into agent memory (ADR-020)
+
+## Implementation Tasks
+
+### Phase 1: Governance enforcement
+
+- [x] `lib/agent-governance.sh` in principled-agent — halt check with reason, blocked-issue
+      count, in-flight PR count, combined `--can-dispatch` gate; bash 3.2, jq optional,
+      degrades cleanly when `gh` is unavailable
+- [x] `--halt <reason>` and `--resume` operations that write and clear `.agents/HALT`
+- [x] `hooks/scripts/check-agent-governance.sh` — advisory warning when a PR is opened or
+      merged in a way the protocol forbids (self-approval, non-draft agent PR)
+- [x] Wire the hook into `hooks/hooks.json`
+
+### Phase 2: Execution modes
+
+- [x] `--mode interactive|supervised|autonomous` documented in `/orchestrate`, defaulting
+      to `interactive` so existing behaviour is unchanged
+- [x] Retry budget (default 2) and 50% phase-failure breaker as explicit stop conditions
+- [x] Halt check at every phase boundary in supervised and autonomous modes; never
+      mid-task, since interrupting a worker leaves a worktree in an unknown state
+- [x] `--max-workers` default 3, documented as an unmeasured conservative default
+- [x] Update `skills/impl-strategy/reference/orchestration-guide.md`
+
+### Phase 3: Workforce skills
+
+- [x] `/agent-dispatch <issue> [--local] [--dry-run]` — governance gate, specialization
+      routing from the registry, `--local` execution, `workflow_dispatch` otherwise
+- [x] `/agent-respond <pr-number>` — read review comments via `gh`, address them, and
+      write durable feedback into the agent's memory file
+- [x] `/agent-status [--all] [--agent <id>]` — halt state, in-flight PRs, blocked issues,
+      per-agent metrics
+- [x] Vendored `lib/check-gh-cli.sh` (fourth copy; add to the cross-plugin drift checker)
+
+### Phase 4: Dispatch backend
+
+- [x] `skills/agent-dispatch/templates/agent-dispatch.yml` — least-privilege permissions,
+      `workflow_dispatch` only by default, `issues` trigger present but commented
+- [x] Installation instructions, and an explicit statement that installing the plugin
+      arms nothing
+- [x] New labels (`agent-ready`, `agent-blocked`, `agent-authored`) added to
+      principled-github's label definitions
+
+### Phase 5: Tests, docs, CI
+
+- [x] `tests/agent-governance.bats` — halt behaviour, budget arithmetic, gate composition,
+      and graceful degradation with no `gh`
+- [x] Extend `tests/hooks.bats` for the governance advisory, including the no-jq path
+- [x] `docs/architecture/agent-collaboration.md` — protocol, governance, dispatch flow
+- [x] Update `docs/architecture/plugin-system.md` for principled-agent's relationships
+- [x] Root `CLAUDE.md`, `.claude/CLAUDE.md`, README, marketplace metadata
+- [x] `just ci` green
+
+## Dependencies
+
+- **Plan-010 (complete).** The registry and memory this plan routes by and writes to.
+- **principled-tasks (ADR-017).** Optional at runtime; used for dependency ordering.
+- **`gh` CLI.** Required for dispatch, `/agent-respond`, and `/agent-status`; every
+  script must degrade with a clear message rather than a stack trace when it is absent.
+- **Agent teams (ADR-016, `proposed`).** The four-role parallel model needs them. Roles
+  are therefore documented as a coordination pattern over shipped skills, and no code in
+  this plan requires teams to be enabled.
+
+## Acceptance Criteria
+
+- [x] `.agents/HALT` blocks dispatch and pauses orchestration at the next phase boundary,
+      and every refusal prints the reason and the file path
+- [x] Dispatch refuses at or above 5 open `agent-blocked` issues or 5 in-flight agent PRs
+- [x] Governance scripts exit cleanly and informatively when `gh` is not installed
+- [x] `/orchestrate` with no `--mode` behaves exactly as before
+- [x] The dispatch workflow is **not** active in this repository, and the template
+      defaults to `workflow_dispatch` only
+- [x] The template requests only `contents`, `issues`, and `pull-requests` write scope
+- [x] `--local` completes the protocol with no CI and no credentials
+- [x] Every new script passes ShellCheck and shfmt and runs on bash 3.2
+- [x] `just ci` passes
+
+## Verification
+
+Machine-tested by `just ci` (158 bats tests, up from 126):
+
+- `lib/agent-governance.sh` — halt engage/clear, refusal-vs-error exit codes, budget
+  arithmetic including the inclusive boundary, fail-closed behaviour when `gh` is
+  unavailable, JSON escaping, and the no-jq count fallback (`tests/agent-governance.bats`,
+  23 tests)
+- the governance advisory hook — non-draft PRs, missing `agent-authored` label,
+  self-approval, merge, ready-for-review promotion, halt surfacing, malformed input, and
+  the no-jq path (`tests/hooks.bats`)
+
+Verified directly against the repository:
+
+- no `agent-dispatch.yml` in `.github/workflows/` — the workflow is not active here
+- the template parses to exactly one trigger (`workflow_dispatch`) and three permissions
+  (`contents`, `issues`, `pull-requests`); `actions: write` appears only in an
+  explanatory comment
+- `scripts/check-skill-references.sh` resolves all 98 references
+- the new labels round-trip through `label-definitions.sh --json`
+
+Delivered as skills, and therefore model-executed rather than machine-tested:
+`/agent-dispatch`, `/agent-respond`, `/agent-status`, and `/orchestrate --mode`. Their
+script dependencies are covered above; the workflow prose is not executable and is not
+claimed to be tested. **The end-to-end protocol has never been run** — no issue has been
+dispatched, and the caps in ADR-022 remain unmeasured defaults.
+
+Corrected in passing: `docs/architecture/plugin-system.md` still asserted ADR-009's
+"scripts have no shared directory" rule, which ADR-018 superseded. Replaced with the
+`lib/` constraint and a new section documenting the cross-plugin file-path contract,
+including the fact that those couplings are invisible to `check-skill-references.sh`.

--- a/docs/proposals/012-github-native-agent-collaboration.md
+++ b/docs/proposals/012-github-native-agent-collaboration.md
@@ -1,7 +1,7 @@
 ---
 title: "GitHub-Native Agent Collaboration and Autonomous Execution"
 number: "012"
-status: draft
+status: accepted
 author: Alex
 created: 2026-07-28
 updated: 2026-07-28
@@ -229,15 +229,88 @@ exists to avoid. The protocol is what makes the modes safe to use.
   boundary is
 - **New ADR:** agent governance constraints (draft PRs, no self-approval, attribution)
 
-## Open Questions
+## Resolved Questions
 
-- **Where do the execution modes live?** `--mode` extends `/orchestrate` in
-  principled-implementation, but dispatch and the protocol are principled-agent. Does
-  that split the orchestrator across two plugins?
-- **How is `agent-blocked` triaged?** Autonomous mode can produce blockers faster than
-  they are read. Should there be a blocked-issue budget that halts dispatch?
-- **What is the concurrency ceiling?** RFC-010 cited 20-30 parallel agents from prior
-  art. What does this repository's CI, GitHub API quota, and review capacity actually
-  support?
-- **Does `--mode autonomous` need a kill switch** reachable from outside the session —
-  a label or a file that halts all dispatch?
+These were open when this proposal was drafted. Each is answered below; the answers are
+binding on the implementation plan.
+
+### Where the execution modes live
+
+**Resolved: `--mode` stays entirely in `/orchestrate`. It does not split the
+orchestrator, because mode and dispatch answer different questions.**
+
+The apparent conflict dissolves once the two are stated precisely:
+
+- **Mode** answers _how much human involvement does this run require?_ That is a property
+  of one orchestration run, and every mechanism it needs — retry budgets, phase
+  boundaries, task state — already lives in the manifest. It needs nothing from the agent
+  registry.
+- **Dispatch** answers _which agent should pick up this work, and is it allowed to start?_
+  That needs the registry and the governance state, and nothing from the manifest.
+
+So `--mode` extends `/orchestrate` in principled-implementation, and dispatch lives in
+principled-agent. The one thing they share is the halt switch, and that is deliberately a
+**file at a fixed repository path** rather than an API: `/orchestrate` checks it at phase
+boundaries and `/agent-dispatch` checks it before dispatching, neither needing to call
+into the other's plugin. Plugins install independently and cannot reference each other's
+`${CLAUDE_PLUGIN_ROOT}` (ADR-018), so a shared file is the only coupling available — and
+here it is also the right one, since the switch must be operable by a human with no
+session at all.
+
+### Triaging `agent-blocked`
+
+**Resolved: a blocked-issue budget that halts dispatch, defaulting to 5.**
+
+When `/agent-dispatch` is asked to start work, it counts open `agent-blocked` issues
+first. At or above the budget it refuses and explains why.
+
+The reasoning is that blockers accumulating faster than a human triages them is not a
+queue-depth problem, it is a signal that something systemic is wrong — a broken test
+suite, a bad plan, a missing credential. Continuing to dispatch converts one systemic
+problem into many, each costing a run and a human triage. Halting is cheap and reversible;
+the accumulated mess is neither.
+
+This is the same family as the 50% phase-failure circuit breaker: both stop the system
+when the evidence says the next attempt will fail the same way.
+
+### The concurrency ceiling
+
+**Resolved: default `--max-workers 3` and a cap of 5 in-flight agent PRs. Both
+configurable. Neither is derived from measurement.**
+
+RFC-010's 20-30 figure came from prior art elsewhere and should not be carried over: this
+repository has never run autonomous dispatch, so any number presented as measured would
+be invented.
+
+What can be reasoned about is which constraint binds first. CI minutes and GitHub API
+quota are real but elastic — they can be raised with money or backoff. **Human review
+capacity cannot**, and the risk register already names review fatigue as the failure that
+is worse than no gate, because a rubber stamp looks like oversight. The binding constraint
+is therefore the reviewer, and the cap belongs on in-flight PRs rather than on parallel
+workers.
+
+The defaults are deliberately conservative. Raise them from observation: if the PR queue
+drains faster than agents fill it, there is headroom; if `agent-blocked` issues
+accumulate, there is not.
+
+### The kill switch
+
+**Resolved: required, file-based, and checked by everything.**
+
+A file at `.agents/HALT` stops all dispatch and pauses orchestration at the next phase
+boundary. Any content is a reason string, surfaced when a run refuses to proceed.
+
+File-based rather than a GitHub label, for three reasons. It works identically under
+`--local` and under CI, so there is one mechanism rather than two that can disagree. It
+requires no API call, so it still works when the API is the thing that is broken. And it
+is operable by anyone with repository write access and no running session — which is the
+entire point of a kill switch, since the person who needs to stop a runaway is usually not
+the person driving it.
+
+The switch is checked before every dispatch and at every phase boundary in `supervised`
+and `autonomous` modes. It is **not** checked mid-task: interrupting a worker halfway
+leaves a worktree in an unknown state, and the phase boundary is the nearest point where
+stopping is clean.
+
+`.agents/HALT` is committed like the rest of `.agents/`, so halting is itself an auditable
+act.

--- a/plugins/principled-agent/hooks/hooks.json
+++ b/plugins/principled-agent/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Principled agent: memory injection at spawn and integrity advisory for .agents/ writes",
+  "description": "Principled agent: memory injection at spawn, integrity advisory for .agents/ writes, and contributor-protocol governance advisory",
   "hooks": {
     "SubagentStart": [
       {
@@ -19,6 +19,16 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/check-memory-integrity.sh",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/check-agent-governance.sh",
             "timeout": 10
           }
         ]

--- a/plugins/principled-agent/hooks/scripts/check-agent-governance.sh
+++ b/plugins/principled-agent/hooks/scripts/check-agent-governance.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# check-agent-governance.sh — Advisory guard for the agent contributor protocol
+# (ADR-022).
+#
+# Fires after a Bash command. Watches for the two governance constraints that are
+# violated by a command rather than by a file edit:
+#
+#   1. An agent PR opened without --draft. Promotion to ready-for-review is a human act.
+#   2. An agent approving or merging a PR. An agent that can approve its own work removes
+#      the only reliable check on a non-deterministic system.
+#
+# It also surfaces an engaged halt switch when a dispatch-shaped command is run, since a
+# halt that goes unnoticed is a halt that gets worked around.
+#
+# Advisory only — always exits 0. The blocking enforcement lives where it can be
+# authoritative: branch protection on the GitHub side, and --can-dispatch before a run
+# starts. A PostToolUse hook fires after the command has already run, so blocking here
+# would be theatre.
+#
+# Input: JSON on stdin with tool_input.command
+# Output: Warnings to stderr
+# Exit: Always 0 (advisory)
+
+set -euo pipefail
+
+input=$(cat 2> /dev/null || true)
+
+command_text=""
+if command -v jq &> /dev/null; then
+  command_text=$(echo "$input" | jq -r '.tool_input.command // empty' 2> /dev/null || true)
+else
+  command_text=$(echo "$input" \
+    | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' \
+    | head -1 \
+    | sed 's/.*"command"[[:space:]]*:[[:space:]]*"//' \
+    | sed 's/"$//' || true)
+fi
+
+if [[ -z "$command_text" ]]; then
+  exit 0
+fi
+
+case "$command_text" in
+*gh\ pr* | *gh\ issue* | *agent-dispatch*) ;;
+*) exit 0 ;;
+esac
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2> /dev/null || pwd)"
+HALT_FILE="${REPO_ROOT}/.agents/HALT"
+
+# --- Halt switch awareness -------------------------------------------------
+if [[ -f "$HALT_FILE" ]]; then
+  case "$command_text" in
+  *agent-dispatch* | *"gh workflow run"*)
+    echo "⚠️  Advisory: the halt switch is engaged, but a dispatch command was run." >&2
+    echo "   File: ${HALT_FILE}" >&2
+    if [[ -s "$HALT_FILE" ]]; then
+      echo "   Reason: $(head -1 "$HALT_FILE")" >&2
+    fi
+    echo "   Clear it deliberately with 'agent-governance.sh --resume' rather than" >&2
+    echo "   working around it — the switch exists to stop a run nobody is watching." >&2
+    ;;
+  esac
+fi
+
+# --- Draft PR constraint ---------------------------------------------------
+case "$command_text" in
+*"gh pr create"*)
+  if [[ "$command_text" != *"--draft"* ]]; then
+    echo "⚠️  Advisory: 'gh pr create' without --draft." >&2
+    echo "   Agents open draft PRs; promotion to ready-for-review is a human act" >&2
+    echo "   (ADR-022). If a human is opening this PR, carry on." >&2
+  fi
+  if [[ "$command_text" != *"agent-authored"* ]]; then
+    echo "⚠️  Advisory: agent PRs should carry the 'agent-authored' label." >&2
+    echo "   The in-flight PR budget is counted by that label, so an unlabelled agent PR" >&2
+    echo "   is invisible to the review-capacity circuit breaker." >&2
+  fi
+  ;;
+esac
+
+# --- Self-approval and merge constraints -----------------------------------
+case "$command_text" in
+*"gh pr review"*)
+  case "$command_text" in
+  *--approve*)
+    echo "⚠️  Advisory: 'gh pr review --approve' detected." >&2
+    echo "   Agents must not approve PRs, including their own (ADR-022). Approval is" >&2
+    echo "   the human gate that makes autonomous execution safe to run at all." >&2
+    ;;
+  esac
+  ;;
+esac
+
+case "$command_text" in
+*"gh pr merge"*)
+  echo "⚠️  Advisory: 'gh pr merge' detected." >&2
+  echo "   No agent mode auto-merges (ADR-022). Merging is a human act; branch" >&2
+  echo "   protection should be enforcing this independently." >&2
+  ;;
+esac
+
+# --- Ready-for-review promotion --------------------------------------------
+case "$command_text" in
+*"gh pr ready"*)
+  echo "⚠️  Advisory: 'gh pr ready' promotes a draft PR to ready-for-review." >&2
+  echo "   That is a human decision under the contributor protocol (ADR-022)." >&2
+  ;;
+esac
+
+exit 0

--- a/plugins/principled-agent/lib/agent-governance.sh
+++ b/plugins/principled-agent/lib/agent-governance.sh
@@ -1,0 +1,356 @@
+#!/usr/bin/env bash
+# agent-governance.sh — Mechanical enforcement of the agent governance constraints
+# (ADR-022).
+#
+# The constraints exist for the case where no human is watching, so "the agent should
+# check" is unfalsifiable exactly when it matters. Each check here is something a script
+# can answer, not something an agent is asked to remember.
+#
+# Usage:
+#   agent-governance.sh --check-halt
+#   agent-governance.sh --halt "<reason>"
+#   agent-governance.sh --resume
+#   agent-governance.sh --count-blocked
+#   agent-governance.sh --count-in-flight
+#   agent-governance.sh --can-dispatch [--blocked-budget N] [--pr-budget N]
+#   agent-governance.sh --status [--format table|json]
+#
+# Exit codes:
+#   0 — permitted (or the queried condition is clear)
+#   1 — usage or environment error
+#   3 — refused by a governance constraint; the reason is printed to stdout
+#
+# Exit 3 is deliberately distinct from 1: a refusal is a successful, expected answer,
+# and a caller must be able to tell "you may not" from "I could not tell".
+#
+# GitHub-dependent counts degrade rather than fail. When `gh` is missing or
+# unauthenticated the count is reported as unknown, and --can-dispatch says so instead
+# of silently treating unknown as zero — an unknown budget must never read as headroom.
+#
+# Constraints: bash 3.2 (stock macOS), jq optional, no GNU-only tooling.
+
+set -euo pipefail
+
+DEFAULT_BLOCKED_BUDGET=5
+DEFAULT_PR_BUDGET=5
+
+OPERATION=""
+REASON=""
+ROOT_PATH=""
+FORMAT="table"
+BLOCKED_BUDGET="$DEFAULT_BLOCKED_BUDGET"
+PR_BUDGET="$DEFAULT_PR_BUDGET"
+
+usage() {
+  sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --check-halt)
+    OPERATION="check-halt"
+    shift
+    ;;
+  --halt)
+    OPERATION="halt"
+    if [[ $# -ge 2 && "$2" != --* ]]; then
+      REASON="$2"
+      shift 2
+    else
+      shift
+    fi
+    ;;
+  --resume)
+    OPERATION="resume"
+    shift
+    ;;
+  --count-blocked)
+    OPERATION="count-blocked"
+    shift
+    ;;
+  --count-in-flight)
+    OPERATION="count-in-flight"
+    shift
+    ;;
+  --can-dispatch)
+    OPERATION="can-dispatch"
+    shift
+    ;;
+  --status)
+    OPERATION="status"
+    shift
+    ;;
+  --blocked-budget)
+    [[ $# -ge 2 ]] || {
+      echo "Error: --blocked-budget requires a value" >&2
+      exit 1
+    }
+    BLOCKED_BUDGET="$2"
+    shift 2
+    ;;
+  --pr-budget)
+    [[ $# -ge 2 ]] || {
+      echo "Error: --pr-budget requires a value" >&2
+      exit 1
+    }
+    PR_BUDGET="$2"
+    shift 2
+    ;;
+  --format)
+    [[ $# -ge 2 ]] || {
+      echo "Error: --format requires a value" >&2
+      exit 1
+    }
+    FORMAT="$2"
+    shift 2
+    ;;
+  --root)
+    [[ $# -ge 2 ]] || {
+      echo "Error: --root requires a value" >&2
+      exit 1
+    }
+    ROOT_PATH="$2"
+    shift 2
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "Error: unknown argument '$1'" >&2
+    usage >&2
+    exit 1
+    ;;
+  esac
+done
+
+if [[ -z "$OPERATION" ]]; then
+  echo "Error: no operation specified" >&2
+  usage >&2
+  exit 1
+fi
+
+for budget in "$BLOCKED_BUDGET" "$PR_BUDGET"; do
+  if [[ ! "$budget" =~ ^[0-9]+$ ]]; then
+    echo "Error: budgets must be non-negative integers (got '${budget}')" >&2
+    exit 1
+  fi
+done
+
+if [[ -z "$ROOT_PATH" ]]; then
+  ROOT_PATH="$(git rev-parse --show-toplevel 2> /dev/null || pwd)"
+fi
+
+AGENTS_DIR="${ROOT_PATH}/.agents"
+HALT_FILE="${AGENTS_DIR}/HALT"
+
+# --- GitHub availability ---------------------------------------------------
+# Never fail on a missing gh: these scripts run inside orchestration loops where an
+# unavailable CLI must produce a clear answer, not a stack trace.
+gh_available() {
+  command -v gh &> /dev/null && gh auth status &> /dev/null
+}
+
+# Count open issues carrying a label. Prints an integer, or "unknown".
+count_open_issues_with_label() {
+  local label="$1"
+  if ! gh_available; then
+    echo "unknown"
+    return 0
+  fi
+  local out
+  out="$(gh issue list --state open --label "$label" --limit 200 --json number 2> /dev/null || echo "")"
+  if [[ -z "$out" ]]; then
+    echo "unknown"
+    return 0
+  fi
+  if command -v jq &> /dev/null; then
+    echo "$out" | jq 'length'
+  else
+    # Each entry contributes exactly one "number" key.
+    printf '%s' "$out" | tr ',' '\n' | grep -c '"number"' || echo 0
+  fi
+}
+
+# Count open PRs that are agent-authored, by label.
+count_in_flight_prs() {
+  if ! gh_available; then
+    echo "unknown"
+    return 0
+  fi
+  local out
+  out="$(gh pr list --state open --label agent-authored --limit 200 --json number 2> /dev/null || echo "")"
+  if [[ -z "$out" ]]; then
+    echo "unknown"
+    return 0
+  fi
+  if command -v jq &> /dev/null; then
+    echo "$out" | jq 'length'
+  else
+    printf '%s' "$out" | tr ',' '\n' | grep -c '"number"' || echo 0
+  fi
+}
+
+halt_reason() {
+  if [[ -s "$HALT_FILE" ]]; then
+    head -20 "$HALT_FILE"
+  else
+    echo "(no reason recorded)"
+  fi
+}
+
+# --- Operation: check-halt -------------------------------------------------
+if [[ "$OPERATION" == "check-halt" ]]; then
+  if [[ -f "$HALT_FILE" ]]; then
+    echo "HALTED"
+    echo "File: ${HALT_FILE}"
+    echo "Reason: $(halt_reason)"
+    echo ""
+    echo "Clear it with: agent-governance.sh --resume"
+    exit 3
+  fi
+  echo "OK: no halt in effect."
+  exit 0
+fi
+
+# --- Operation: halt -------------------------------------------------------
+if [[ "$OPERATION" == "halt" ]]; then
+  mkdir -p "$AGENTS_DIR"
+  if [[ -z "$REASON" ]]; then
+    REASON="Halted manually; no reason given."
+  fi
+  printf '%s\n' "$REASON" > "$HALT_FILE"
+  echo "Halt engaged. All dispatch will refuse; orchestration pauses at the next phase boundary."
+  echo "File: ${HALT_FILE}"
+  echo "Reason: ${REASON}"
+  echo ""
+  echo "Commit it so the halt is visible to everyone: git add .agents/HALT"
+  exit 0
+fi
+
+# --- Operation: resume -----------------------------------------------------
+if [[ "$OPERATION" == "resume" ]]; then
+  if [[ ! -f "$HALT_FILE" ]]; then
+    echo "No halt in effect; nothing to clear."
+    exit 0
+  fi
+  echo "Clearing halt. Previous reason: $(halt_reason)"
+  rm -f "$HALT_FILE"
+  echo "Halt cleared. Commit the removal: git add -A .agents/"
+  exit 0
+fi
+
+# --- Operation: count-blocked ----------------------------------------------
+if [[ "$OPERATION" == "count-blocked" ]]; then
+  count_open_issues_with_label "agent-blocked"
+  exit 0
+fi
+
+# --- Operation: count-in-flight --------------------------------------------
+if [[ "$OPERATION" == "count-in-flight" ]]; then
+  count_in_flight_prs
+  exit 0
+fi
+
+# --- Operation: can-dispatch -----------------------------------------------
+# The single gate every dispatch passes through. Checks the halt switch first
+# because it is the only one that works without network access.
+if [[ "$OPERATION" == "can-dispatch" ]]; then
+  if [[ -f "$HALT_FILE" ]]; then
+    echo "REFUSED: halt switch engaged."
+    echo "File: ${HALT_FILE}"
+    echo "Reason: $(halt_reason)"
+    echo ""
+    echo "Clear it with: agent-governance.sh --resume"
+    exit 3
+  fi
+
+  BLOCKED="$(count_open_issues_with_label "agent-blocked")"
+  IN_FLIGHT="$(count_in_flight_prs)"
+
+  if [[ "$BLOCKED" == "unknown" || "$IN_FLIGHT" == "unknown" ]]; then
+    echo "REFUSED: cannot verify governance budgets."
+    echo "The gh CLI is unavailable or unauthenticated, so open agent-blocked issues"
+    echo "and in-flight agent PRs could not be counted."
+    echo ""
+    echo "An unverifiable budget is not headroom. Authenticate with 'gh auth login',"
+    echo "or dispatch with --local, which needs no GitHub access."
+    exit 3
+  fi
+
+  if [[ "$BLOCKED" -ge "$BLOCKED_BUDGET" ]]; then
+    echo "REFUSED: ${BLOCKED} open agent-blocked issue(s), budget is ${BLOCKED_BUDGET}."
+    echo ""
+    echo "Blockers accumulating faster than they are triaged is a systemic signal, not"
+    echo "queue depth. Triage the existing blockers before dispatching more work."
+    exit 3
+  fi
+
+  if [[ "$IN_FLIGHT" -ge "$PR_BUDGET" ]]; then
+    echo "REFUSED: ${IN_FLIGHT} in-flight agent PR(s), budget is ${PR_BUDGET}."
+    echo ""
+    echo "Review capacity is the binding constraint (ADR-022). Opening more PRs than"
+    echo "reviewers can absorb turns the human gate into a rubber stamp."
+    exit 3
+  fi
+
+  echo "OK: dispatch permitted."
+  echo "  agent-blocked issues: ${BLOCKED}/${BLOCKED_BUDGET}"
+  echo "  in-flight agent PRs:  ${IN_FLIGHT}/${PR_BUDGET}"
+  exit 0
+fi
+
+# --- Operation: status -----------------------------------------------------
+if [[ "$OPERATION" == "status" ]]; then
+  case "$FORMAT" in
+  table | json) ;;
+  *)
+    echo "Error: unknown format '${FORMAT}' (expected table or json)" >&2
+    exit 1
+    ;;
+  esac
+
+  HALTED="false"
+  HALT_TEXT=""
+  if [[ -f "$HALT_FILE" ]]; then
+    HALTED="true"
+    HALT_TEXT="$(halt_reason | head -1)"
+  fi
+  BLOCKED="$(count_open_issues_with_label "agent-blocked")"
+  IN_FLIGHT="$(count_in_flight_prs)"
+
+  if [[ "$FORMAT" == "json" ]]; then
+    esc_halt="$(printf '%s' "$HALT_TEXT" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+    printf '{\n'
+    printf '  "halted": %s,\n' "$HALTED"
+    printf '  "halt_reason": "%s",\n' "$esc_halt"
+    if [[ "$BLOCKED" == "unknown" ]]; then
+      printf '  "agent_blocked_issues": null,\n'
+    else
+      printf '  "agent_blocked_issues": %s,\n' "$BLOCKED"
+    fi
+    if [[ "$IN_FLIGHT" == "unknown" ]]; then
+      printf '  "in_flight_prs": null,\n'
+    else
+      printf '  "in_flight_prs": %s,\n' "$IN_FLIGHT"
+    fi
+    printf '  "blocked_budget": %s,\n' "$BLOCKED_BUDGET"
+    printf '  "pr_budget": %s\n' "$PR_BUDGET"
+    printf '}\n'
+  else
+    printf '%-24s %s\n' "Halted:" "$HALTED"
+    if [[ "$HALTED" == "true" ]]; then
+      printf '%-24s %s\n' "Halt reason:" "$HALT_TEXT"
+    fi
+    printf '%-24s %s/%s\n' "agent-blocked issues:" "$BLOCKED" "$BLOCKED_BUDGET"
+    printf '%-24s %s/%s\n' "In-flight agent PRs:" "$IN_FLIGHT" "$PR_BUDGET"
+    if [[ "$BLOCKED" == "unknown" || "$IN_FLIGHT" == "unknown" ]]; then
+      printf '\n%s\n' "Note: 'unknown' means gh is unavailable or unauthenticated."
+      printf '%s\n' "Dispatch refuses on an unknown budget rather than assuming headroom."
+    fi
+  fi
+  exit 0
+fi
+
+echo "Error: unhandled operation '$OPERATION'" >&2
+exit 1

--- a/plugins/principled-agent/lib/check-gh-cli.sh
+++ b/plugins/principled-agent/lib/check-gh-cli.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# check-gh-cli.sh — Verify that the GitHub CLI (gh) is installed and authenticated.
+#
+# Usage: check-gh-cli.sh
+#
+# Checks:
+#   1. gh is on PATH
+#   2. gh auth status succeeds (user is logged in)
+#
+# Exit codes:
+#   0 — gh is available and authenticated
+#   1 — gh is missing or not authenticated
+
+set -euo pipefail
+
+# Check if gh is installed
+if ! command -v gh &> /dev/null; then
+  echo "Error: gh CLI is not installed." >&2
+  echo "Install it from https://cli.github.com/" >&2
+  exit 1
+fi
+
+# Check if gh is authenticated
+if ! gh auth status &> /dev/null; then
+  echo "Error: gh CLI is not authenticated." >&2
+  echo "Run 'gh auth login' to authenticate." >&2
+  exit 1
+fi
+
+echo "OK: gh CLI is available and authenticated."
+exit 0

--- a/plugins/principled-agent/skills/agent-dispatch/SKILL.md
+++ b/plugins/principled-agent/skills/agent-dispatch/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: agent-dispatch
+description: >
+  Assign a GitHub issue to an agent and start work on it, either in the current
+  session or via the configured CI backend. Enforces the governance gate first:
+  halt switch, open blocker budget, and in-flight PR budget. Use to hand an
+  agent a piece of the backlog.
+allowed-tools: Read, Write, Bash(bash plugins/*), Bash(bash scripts/*), Bash(gh *), Bash(git *), Bash(ls *), Bash(test *), Bash(cat *)
+user-invocable: true
+---
+
+# Agent Dispatch — Assign Work to an Agent
+
+Start agent work on an issue, after checking that it is allowed to start at all.
+
+## Command
+
+```
+/agent-dispatch <issue-number> [--local] [--agent <id>] [--dry-run]
+```
+
+## Arguments
+
+| Argument         | Required | Description                                                     |
+| ---------------- | -------- | --------------------------------------------------------------- |
+| `<issue-number>` | Yes      | GitHub issue to work on                                         |
+| `--local`        | No       | Run in the current session instead of CI. No credentials needed |
+| `--agent <id>`   | No       | Override routing and assign a specific agent                    |
+| `--dry-run`      | No       | Report the gate result and routing, then stop                   |
+
+## The gate comes first
+
+**Run this before anything else, including reading the issue.** It is the mechanism that
+makes unattended execution safe (ADR-022), and it is cheap:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/lib/agent-governance.sh" --can-dispatch
+```
+
+| Exit | Meaning                                                                |
+| ---- | ---------------------------------------------------------------------- |
+| 0    | Permitted. Proceed                                                     |
+| 3    | Refused. **Stop.** Print the reason verbatim and do not work around it |
+| 1    | Environment error. Report it; do not treat it as permission            |
+
+A refusal is a successful answer, not an obstacle. The three refusals mean:
+
+- **Halt engaged** — someone stopped the system deliberately. Clearing it is their call,
+  not this session's.
+- **Blocker budget exhausted** — blockers are outpacing triage, which is a systemic
+  signal. More dispatch makes it worse.
+- **Budgets unverifiable** — `gh` is unavailable, so the counts are unknown. An unknown
+  budget is not headroom. Suggest `--local`, which needs no GitHub access.
+
+Never re-run the gate with raised `--blocked-budget` or `--pr-budget` values to get past
+a refusal. Raising a cap is a human decision made deliberately, not a retry strategy.
+
+## Workflow
+
+1. **Gate.** As above. Under `--dry-run`, report the result and stop here.
+
+2. **Verify `gh`** (skip under `--local` if the issue body is already supplied):
+
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/lib/check-gh-cli.sh"
+   ```
+
+3. **Read the issue.**
+
+   ```bash
+   gh issue view <issue-number> --json number,title,body,labels,assignees
+   ```
+
+   Confirm it carries `agent-ready`. If not, say so and stop — the label is how a human
+   signals that an issue is understood well enough to hand over.
+
+4. **Route to an agent.** Unless `--agent` is given, pick from the registry by matching
+   the issue's labels and content against each agent's `specializations`:
+
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/lib/agent-memory.sh" --list
+   ```
+
+   Only agents with `memory: true` are dispatch targets; the deterministic auditors run
+   as hooks and are not assignable. If nothing matches well, default to `impl-worker` and
+   say that the routing was a fallback rather than a match.
+
+5. **Execute.**
+
+   **With `--local`** — run the protocol in this session, no CI, no credentials:
+
+   | Step | Action                                                | Gate               |
+   | ---- | ----------------------------------------------------- | ------------------ |
+   | 1    | `/ingest-issue <n>` → draft proposal                  | **Human approves** |
+   | 2    | `/new-plan --from-proposal NNN`                       | **Human approves** |
+   | 3    | `/orchestrate <plan> --mode supervised`               | Stop conditions    |
+   | 4    | `/review-checklist` self-review                       | —                  |
+   | 5    | `/pr-describe` → **draft** PR, `agent-authored` label | **Human reviews**  |
+   | 6    | Human merges                                          | **Human merges**   |
+
+   The approval gates are the point. Stop and ask at each one; do not infer approval from
+   silence or from the fact that nobody objected last time.
+
+   **Without `--local`** — trigger the configured backend:
+
+   ```bash
+   gh workflow run agent-dispatch.yml -f issue=<issue-number> -f agent=<agent-id>
+   ```
+
+   If the workflow does not exist, say so plainly: it ships as an opt-in template and is
+   not installed by default (ADR-023). Point at
+   `${CLAUDE_PLUGIN_ROOT}/skills/agent-dispatch/templates/agent-dispatch.yml` and offer
+   `--local`, which needs no infrastructure at all.
+
+6. **Record the assignment.**
+
+   ```bash
+   gh issue comment <issue-number> --body "Dispatched to <agent-id>. Progress will be posted here."
+   ```
+
+   When principled-tasks is installed, open a task linking the issue so the work is
+   visible in the graph. Skip silently when it is not.
+
+## Reporting
+
+State the gate result with its numbers, which agent was chosen and whether that was a
+match or a fallback, the execution path taken, and the next human gate. If refused, lead
+with the refusal and its reason — never bury it under what you would have done.
+
+## Scripts
+
+- `${CLAUDE_PLUGIN_ROOT}/lib/agent-governance.sh` — the governance gate (ADR-022)
+- `${CLAUDE_PLUGIN_ROOT}/lib/agent-memory.sh` — registry and routing (ADR-018)
+- `${CLAUDE_PLUGIN_ROOT}/lib/check-gh-cli.sh` — gh availability
+
+## Templates
+
+- `${CLAUDE_PLUGIN_ROOT}/skills/agent-dispatch/templates/agent-dispatch.yml` — opt-in
+  GitHub Actions backend (ADR-023). Not installed by default

--- a/plugins/principled-agent/skills/agent-dispatch/templates/agent-dispatch.yml
+++ b/plugins/principled-agent/skills/agent-dispatch/templates/agent-dispatch.yml
@@ -1,0 +1,149 @@
+# Agent dispatch — opt-in GitHub Actions backend for the Agent Contributor Protocol.
+#
+# THIS FILE IS A TEMPLATE. Installing principled-agent does not install it, and
+# installing it does not enable automatic dispatch (ADR-023).
+#
+# To use it:
+#   1. Copy to .github/workflows/agent-dispatch.yml
+#   2. Add ANTHROPIC_API_KEY to repository secrets
+#   3. Create the labels: agent-ready, agent-blocked, agent-authored
+#   4. Run it manually from the Actions tab, or via:
+#        gh workflow run agent-dispatch.yml -f issue=<number>
+#
+# Automatic dispatch on `agent-ready` is DELIBERATELY COMMENTED OUT below. Enabling it
+# means agents start work with no human present, so it should be a visible, reviewable
+# diff rather than a default inherited from installing a plugin.
+#
+# Before enabling it, make sure you have:
+#   - Branch protection on your default branch, with required reviews
+#   - A plan for who triages agent-blocked issues, and how often
+#   - Agreement that the caps in ADR-022 match your actual review capacity
+
+name: Agent Dispatch
+
+on:
+  # Manual dispatch only, by default.
+  workflow_dispatch:
+    inputs:
+      issue:
+        description: "Issue number to work on"
+        required: true
+        type: string
+      agent:
+        description: "Agent to assign (blank routes by specialization)"
+        required: false
+        type: string
+      mode:
+        description: "Autonomy level"
+        required: false
+        default: supervised
+        type: choice
+        options:
+          - supervised
+          - autonomous
+  # Automatic dispatch. Read the header before uncommenting.
+  #
+  # issues:
+  #   types: [labeled]
+
+# Least privilege (ADR-023). Notably absent:
+#   actions: write  — a compromised run must not be able to rewrite this workflow
+#   id-token        — no OIDC federation is needed
+# Nothing here grants organization scope.
+permissions:
+  contents: write # branches and commits
+  issues: write # progress comments, agent-blocked
+  pull-requests: write # draft PRs
+
+# One dispatch per issue at a time. Without this, a re-labelled issue starts a second
+# agent on the same work and the two race on the same branch.
+concurrency:
+  group: agent-dispatch-${{ github.event.inputs.issue || github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    # When the `issues` trigger is enabled, only act on the agent-ready label.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event.label.name == 'agent-ready'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # worktree isolation and changelog generation need history
+
+      - name: Check the halt switch
+        # The halt switch must be honoured before any work begins, and it is just a
+        # committed file — no API call, so it still works when the API is what broke.
+        run: |
+          if [ -f .agents/HALT ]; then
+            echo "::error::Halt switch engaged. Dispatch refused."
+            echo "Reason: $(head -1 .agents/HALT)"
+            echo "Clear it with: agent-governance.sh --resume"
+            exit 1
+          fi
+          echo "No halt in effect."
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install the Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Check governance budgets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Refuses on an engaged halt, an exhausted blocker budget, an exhausted
+          # in-flight PR budget, or budgets it cannot verify. Exit 3 is a refusal
+          # rather than an error, and is reported as such.
+          set +e
+          bash .claude/plugins/principled-agent/lib/agent-governance.sh --can-dispatch
+          status=$?
+          set -e
+          if [ "$status" -eq 3 ]; then
+            echo "::error::Dispatch refused by a governance constraint (see above)."
+            exit 1
+          elif [ "$status" -ne 0 ]; then
+            echo "::error::Could not evaluate governance state; refusing to dispatch."
+            exit 1
+          fi
+
+      - name: Run the agent
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.inputs.issue || github.event.issue.number }}
+          AGENT: ${{ github.event.inputs.agent }}
+          MODE: ${{ github.event.inputs.mode || 'supervised' }}
+        run: |
+          claude --print --permission-mode acceptEdits \
+            "/agent-dispatch ${ISSUE} --local ${AGENT:+--agent $AGENT}
+
+            Run in --mode ${MODE}. Honour every governance constraint in ADR-022:
+            open a DRAFT pull request labelled agent-authored, never approve or merge
+            anything, and stop at the next phase boundary if .agents/HALT appears."
+
+      - name: File a blocker on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.inputs.issue || github.event.issue.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh issue create \
+            --title "agent-blocked: dispatch failed for issue #${ISSUE}" \
+            --label agent-blocked \
+            --body "Dispatch for #${ISSUE} failed.
+
+          Run: ${RUN_URL}
+
+          This counts against the blocker budget (ADR-022). Once open blockers reach
+          the budget, further dispatch is refused until they are triaged — that is
+          deliberate: blockers outpacing triage is a systemic signal, not queue depth."

--- a/plugins/principled-agent/skills/agent-respond/SKILL.md
+++ b/plugins/principled-agent/skills/agent-respond/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: agent-respond
+description: >
+  Address review feedback on an agent-authored PR, and promote the durable
+  lessons into agent memory so the same correction is not needed again. Use
+  when a human has reviewed an agent PR and requested changes.
+allowed-tools: Read, Write, Edit, Bash(bash plugins/*), Bash(bash scripts/*), Bash(gh *), Bash(git *), Bash(ls *), Bash(cat *)
+user-invocable: true
+---
+
+# Agent Respond — Address PR Review Feedback
+
+Act on review comments, and close the loop by writing what was learned into memory.
+
+## Command
+
+```
+/agent-respond <pr-number> [--agent <id>] [--no-promote]
+```
+
+## Arguments
+
+| Argument       | Required | Description                                                   |
+| -------------- | -------- | ------------------------------------------------------------- |
+| `<pr-number>`  | Yes      | PR carrying the review feedback                               |
+| `--agent <id>` | No       | Agent whose memory to update. Inferred from the PR if omitted |
+| `--no-promote` | No       | Address the feedback but write nothing to memory              |
+
+## Why this exists
+
+Without it, a reviewer corrects the same thing on every PR forever. The correction lands
+in a comment thread, the session ends, and the next agent starts with no knowledge of it.
+
+This skill is the mechanism by which review feedback stops repeating: durable corrections
+become memory (ADR-020), which is injected at the next spawn.
+
+## Workflow
+
+1. **Verify `gh` and read the review.**
+
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/lib/check-gh-cli.sh"
+   gh pr view <pr-number> --json number,title,author,isDraft,reviews,comments,files
+   gh api "repos/{owner}/{repo}/pulls/<pr-number>/comments"
+   ```
+
+   The second call matters: `gh pr view` returns review summaries, not inline
+   line-level comments, and inline comments are usually where the substance is.
+
+2. **Separate the feedback.** Sort every comment into three buckets, because they get
+   different treatment:
+
+   | Kind           | Example                                 | Action                        |
+   | -------------- | --------------------------------------- | ----------------------------- |
+   | **Defect**     | "this crashes on empty input"           | Fix, then reply               |
+   | **Convention** | "we use `lib/` for shared scripts here" | Fix **and** promote to memory |
+   | **Preference** | "I'd have named this differently"       | Judgement; reply either way   |
+
+   Only conventions are memory candidates. A defect is a fact about one PR; a convention
+   is a fact about the codebase that will apply to every future one.
+
+3. **Address each item.** Make the changes, then commit with attribution:
+
+   ```bash
+   git commit -m "review: <what changed>
+
+   Addresses review feedback on #<pr-number>.
+
+   Co-Authored-By: Claude <noreply@anthropic.com>"
+   ```
+
+4. **Reply to each thread**, saying what was done or why it was not. A comment left
+   unanswered reads as ignored, which costs the reviewer's trust more than a disagreement
+   does.
+
+   ```bash
+   gh pr comment <pr-number> --body "<response>"
+   ```
+
+   Disagreeing is legitimate — say so with reasoning and leave the thread open for the
+   human. Do not silently decline.
+
+5. **Promote conventions to memory** (unless `--no-promote`). For each convention, apply
+   the `agent-strategy` standard — durable, certain, not already present — then append to
+   the agent's `## Known Patterns` via `/agent-memory --learn`.
+
+   Write the **rule**, not the incident. "PR #34 used the wrong path" teaches nothing;
+   "shared scripts live in the plugin's `lib/`, referenced via `${CLAUDE_PLUGIN_ROOT}`"
+   prevents the next occurrence.
+
+   Then record the round:
+
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/lib/agent-memory.sh" --update-metrics --agent <id> --session
+   ```
+
+6. **Leave the PR a draft.** Addressing feedback does not make a PR ready — promotion and
+   merge are human acts (ADR-022). Do not run `gh pr ready`, `gh pr review --approve`, or
+   `gh pr merge`.
+
+## Reporting
+
+List each comment with what was done, flag anything deliberately not done and why, and
+state exactly which lines were added to memory so the reviewer can object to a bad
+learning before it compounds.
+
+## Scripts
+
+- `${CLAUDE_PLUGIN_ROOT}/lib/agent-memory.sh` — memory interface (ADR-018, ADR-020)
+- `${CLAUDE_PLUGIN_ROOT}/lib/check-gh-cli.sh` — gh availability

--- a/plugins/principled-agent/skills/agent-status/SKILL.md
+++ b/plugins/principled-agent/skills/agent-status/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: agent-status
+description: >
+  Report the state of the agent workforce: whether the halt switch is engaged,
+  how much governance budget remains, what work is in flight, and each agent's
+  accumulated metrics. Use to check whether dispatch is possible and where the
+  queue actually stands.
+allowed-tools: Read, Bash(bash plugins/*), Bash(bash scripts/*), Bash(gh *), Bash(git *), Bash(ls *), Bash(cat *), Bash(test *)
+user-invocable: true
+---
+
+# Agent Status — Workforce Report
+
+Answer two questions: can work start right now, and what is already running?
+
+## Command
+
+```
+/agent-status [--all] [--agent <id>] [--format table|json]
+```
+
+## Arguments
+
+| Argument       | Required | Description                                              |
+| -------------- | -------- | -------------------------------------------------------- |
+| `--all`        | No       | Include per-agent memory metrics and orchestration state |
+| `--agent <id>` | No       | Restrict the report to one agent                         |
+| `--format`     | No       | `table` (default) or `json`                              |
+
+## Workflow
+
+1. **Governance state.** Lead with this — it determines whether anything can start:
+
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/lib/agent-governance.sh" --status
+   ```
+
+   Reports halt state and reason, open `agent-blocked` issues against budget, and
+   in-flight `agent-authored` PRs against budget.
+
+   **Report `unknown` as `unknown`.** When `gh` is unavailable the counts cannot be
+   determined, and dispatch refuses rather than assuming headroom. Presenting an unknown
+   budget as zero would invert the safety property this whole layer exists for.
+
+2. **Agent registry and memory** (with `--all` or `--agent`):
+
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/lib/agent-memory.sh" --list
+   ```
+
+   Show session counts, task totals, success rates, and memory size against the context
+   budget. Flag anything over 8 KB as a synthesis candidate.
+
+3. **Orchestration state**, if a run exists. `.impl/manifest.json` belongs to
+   principled-implementation, which may not be installed and cannot be called across the
+   plugin boundary (ADR-018) — so read the file directly with Read:
+   - plan, phase in progress, task counts by status
+   - `checkpoint.orchestrator_summary`, which says what the last session was thinking
+
+   Skip this section silently when there is no manifest.
+
+4. **In-flight work**, when `gh` is available:
+
+   ```bash
+   gh pr list --state open --label agent-authored --json number,title,isDraft,createdAt
+   gh issue list --state open --label agent-blocked --json number,title,createdAt
+   ```
+
+   For each PR, show age and draft status. **A non-draft agent PR is a governance
+   violation** (ADR-022) — call it out rather than listing it neutrally.
+
+   Sort blocked issues oldest first. Age is the signal that matters: blockers nobody has
+   triaged in a week are why the dispatch budget exists.
+
+## Reporting
+
+Lead with whether dispatch is possible right now and why. Then in-flight work, then
+per-agent metrics if requested.
+
+Be direct about problems rather than tabulating around them: a halt in effect, an
+exhausted budget, a non-draft agent PR, and a memory file over budget are all findings,
+not rows. If everything is clear, say so in one line.
+
+## Scripts
+
+- `${CLAUDE_PLUGIN_ROOT}/lib/agent-governance.sh` — governance state (ADR-022)
+- `${CLAUDE_PLUGIN_ROOT}/lib/agent-memory.sh` — registry and metrics (ADR-018)

--- a/plugins/principled-github/skills/sync-labels/scripts/label-definitions.sh
+++ b/plugins/principled-github/skills/sync-labels/scripts/label-definitions.sh
@@ -56,6 +56,13 @@ LABELS=(
   # Document type
   "type:rfc|C5DEF5|Proposal / RFC document"
   "type:plan|BFD4F2|DDD Implementation Plan"
+
+  # Agent workforce (ADR-022). These are load-bearing, not decorative:
+  # agent-blocked is counted against the dispatch budget, and agent-authored is
+  # how in-flight agent PRs are counted for the review-capacity circuit breaker.
+  "agent-ready|1D76DB|Issue is understood well enough to hand to an agent"
+  "agent-blocked|D93F0B|Agent could not proceed; counts against the dispatch budget"
+  "agent-authored|8250DF|Opened by an agent; counts against the in-flight PR budget"
 )
 
 case "$ACTION" in

--- a/plugins/principled-implementation/skills/impl-strategy/reference/orchestration-guide.md
+++ b/plugins/principled-implementation/skills/impl-strategy/reference/orchestration-guide.md
@@ -91,9 +91,53 @@ The orchestrator decides what to do based on failure context:
 | Merge conflict              | Pause for user           | Requires human judgment           |
 | All tasks in phase failed   | Pause for user           | Phase may need re-decomposition   |
 
-## Agent Teams Execution Mode
+## Autonomy: the `--mode` flag
 
-When `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set, the orchestrator uses agent teams for parallel task execution within phases. See [ADR-016](../../../../docs/decisions/016-agent-teams-for-parallel-execution.md) for the architectural decision.
+Distinct from the parallelism setting below. **Parallelism asks how many tasks run at
+once; autonomy asks how much human involvement the run requires.** They are independent —
+any autonomy level runs under either parallelism strategy — and both get called "mode",
+which is the source of most confusion here.
+
+| `--mode`      | Behaviour                                 | Human involvement      |
+| ------------- | ----------------------------------------- | ---------------------- |
+| `interactive` | Default; unchanged from before RFC-012    | Continuous             |
+| `supervised`  | Runs on, pausing at decision points       | At decision gates      |
+| `autonomous`  | Runs end to end, posts results for review | Post-completion review |
+
+### Stop conditions
+
+Active in `supervised` and `autonomous`. Each encodes the same judgement: the evidence
+says the next attempt fails the same way, so stop and surface it rather than escalate
+([ADR-022](../../../../docs/decisions/022-agent-governance-constraints.md)).
+
+| Condition                  | Default | Action                                     |
+| -------------------------- | ------- | ------------------------------------------ |
+| `.agents/HALT` exists      | —       | Pause at the next phase boundary           |
+| Task retry budget exceeded | 2       | Abandon the task, file `agent-blocked`     |
+| Phase task-failure rate    | 50%     | Stop the run — systemic, not one hard task |
+
+**The halt switch is checked only at phase boundaries.** Interrupting a worker mid-task
+leaves a worktree in an unknown state; the phase boundary is the nearest clean stop.
+
+principled-agent owns `.agents/HALT`, but plugins cannot reference each other's
+`${CLAUDE_PLUGIN_ROOT}` ([ADR-018](../../../../docs/decisions/018-shared-plugin-lib-over-copies.md)),
+so **the path is the contract** — test for the file directly rather than calling into
+another plugin. An absent `.agents/` directory means no halt switch, not a halted run.
+
+A run stopped by any of these is **halted, not complete**. Report it that way; a run that
+stopped early and a run that finished are different outcomes.
+
+### Autonomous mode obligations
+
+Before opening anything, run `/pr-describe`, `/review-checklist`, and `/release-ready`,
+then open a **draft** PR labelled `agent-authored`. Both are load-bearing: promotion to
+ready-for-review is a human act, and the in-flight PR budget is counted by that label, so
+an unlabelled agent PR is invisible to the review-capacity circuit breaker. Never
+approve, promote, or merge — no mode auto-merges.
+
+## Parallelism: Agent Teams Execution Mode
+
+When `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set, the orchestrator uses agent teams for parallel task execution within phases, capped by `--max-workers` (default 3). See [ADR-016](../../../../docs/decisions/016-agent-teams-for-parallel-execution.md) for the architectural decision.
 
 ### Dual State Model
 

--- a/plugins/principled-implementation/skills/orchestrate/SKILL.md
+++ b/plugins/principled-implementation/skills/orchestrate/SKILL.md
@@ -18,32 +18,95 @@ Execute a complete DDD plan from decomposition through validation and merge, man
 
 ```
 /orchestrate <plan-path> [--phase <N>] [--continue] [--dry-run]
+             [--mode interactive|supervised|autonomous] [--max-workers <N>]
 ```
 
 ## Arguments
 
-| Argument      | Required | Description                                          |
-| ------------- | -------- | ---------------------------------------------------- |
-| `<plan-path>` | Yes      | Path to DDD plan file                                |
-| `--phase <N>` | No       | Execute only phase N (skip earlier completed phases) |
-| `--continue`  | No       | Resume from existing manifest (skip decomposition)   |
-| `--dry-run`   | No       | Decompose and plan but do not execute                |
+| Argument        | Required | Description                                                |
+| --------------- | -------- | ---------------------------------------------------------- |
+| `<plan-path>`   | Yes      | Path to DDD plan file                                      |
+| `--phase <N>`   | No       | Execute only phase N (skip earlier completed phases)       |
+| `--continue`    | No       | Resume from existing manifest (skip decomposition)         |
+| `--dry-run`     | No       | Decompose and plan but do not execute                      |
+| `--mode <mode>` | No       | Autonomy level. Default `interactive` — existing behaviour |
+| `--max-workers` | No       | Concurrent workers under agent teams. Default 3            |
 
-## Execution Modes
+## Two orthogonal axes
 
-The orchestrator supports two execution modes, selected automatically at runtime:
+"Mode" means two different things here, and conflating them causes real confusion. They
+are independent — any autonomy level can run under either parallelism strategy.
 
-### Sequential Mode (default)
+| Axis            | Selected by                            | Answers                               |
+| --------------- | -------------------------------------- | ------------------------------------- |
+| **Parallelism** | `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` | How many tasks run at once?           |
+| **Autonomy**    | `--mode`                               | How much human involvement is needed? |
 
-When `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` is not set, tasks within a phase execute sequentially via `/spawn`. This is the proven, stable execution path.
+### Parallelism: sequential or agent teams
 
-### Agent Teams Mode (opt-in)
+**Sequential (default).** When `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` is not set, tasks
+within a phase execute sequentially via `/spawn`. This is the proven, stable path.
 
-When `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set, independent tasks within a phase execute concurrently via agent teams. The orchestrator becomes the team lead, spawning one teammate per independent task.
+**Agent teams (opt-in).** When `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`, independent
+tasks within a phase execute concurrently, capped by `--max-workers`. The orchestrator
+becomes the team lead, spawning one teammate per independent task.
 
-**Dual state model:** The agent teams task list drives coordination (claiming, dependencies, completion), while `.impl/manifest.json` remains the persistent record. The lead synchronizes between the two.
+**Dual state model:** the agent teams task list drives coordination (claiming,
+dependencies, completion), while `.impl/manifest.json` remains the persistent record.
+The lead synchronizes between the two.
 
-See [ADR-016](../../docs/decisions/016-agent-teams-for-parallel-execution.md) for the architectural decision and [orchestration-guide.md](../impl-strategy/reference/orchestration-guide.md) for detailed documentation.
+See [ADR-016](../../docs/decisions/016-agent-teams-for-parallel-execution.md) and
+[orchestration-guide.md](../impl-strategy/reference/orchestration-guide.md).
+
+### Autonomy: `--mode`
+
+| Mode          | Behaviour                                 | Human involvement      |
+| ------------- | ----------------------------------------- | ---------------------- |
+| `interactive` | Current behaviour, unchanged              | Continuous             |
+| `supervised`  | Runs on, pausing at decision points       | At decision gates      |
+| `autonomous`  | Runs end to end, posts results for review | Post-completion review |
+
+**`--mode` defaults to `interactive`, so omitting it behaves exactly as before.**
+
+**Supervised** reports at each phase boundary and continues automatically _unless_ a stop
+condition fires (below).
+
+**Autonomous** runs decompose → spawn → validate → merge without pausing, maintains a
+live progress issue, and finishes by running `/pr-describe`, `/review-checklist`, and
+`/release-ready` before opening a **draft** PR labelled `agent-authored`. If blocked, it
+files an `agent-blocked` issue with diagnostics rather than stalling.
+
+## Stop conditions
+
+These apply in `supervised` and `autonomous` modes. Each says the same thing: the
+evidence indicates the next attempt fails the same way, so stop and surface it rather
+than escalating (ADR-022).
+
+| Condition                  | Default | Action                                     |
+| -------------------------- | ------- | ------------------------------------------ |
+| Halt switch present        | —       | Pause at the next phase boundary           |
+| Task retry budget exceeded | 2       | Stop the task, file `agent-blocked`        |
+| Phase task-failure rate    | 50%     | Stop the run — systemic, not one hard task |
+
+**The halt switch is checked at every phase boundary**, never mid-task. Interrupting a
+worker halfway leaves a worktree in an unknown state; the phase boundary is the nearest
+point where stopping is clean.
+
+principled-agent owns the switch but may not be installed, and plugins cannot reference
+each other's `${CLAUDE_PLUGIN_ROOT}` (ADR-018). **The file path is the contract**, so
+check it directly rather than calling into another plugin:
+
+```bash
+test -f .agents/HALT && cat .agents/HALT
+```
+
+If it exists, stop at the phase boundary, print the reason, and report clearly that the
+run was halted rather than completed. If `.agents/` does not exist at all, there is no
+halt switch and the run proceeds — an uninitialized repository is not a halted one.
+
+`--max-workers` defaults to 3. That is a deliberately conservative default, not a
+measurement: this repository has never run autonomous dispatch, and review capacity —
+not CI or API quota — is the constraint that actually binds (ADR-022).
 
 ## Workflow
 
@@ -173,7 +236,40 @@ For each task in the phase:
 
 2. **Report phase results.** Display: tasks merged, failed, abandoned.
 
-3. **Advance to next phase.** Return to Stage 2 for the next phase.
+3. **Evaluate stop conditions** (`supervised` and `autonomous` only). This is the phase
+   boundary, and the only place a run stops cleanly.
+
+   a. **Halt switch.** If `.agents/HALT` exists, stop here. Print its contents as the
+   reason, state plainly that the run was **halted, not completed**, and give the
+   `--continue` command for resuming once the halt is cleared. Do not begin the next
+   phase.
+
+   b. **Phase failure rate.** If more than 50% of this phase's tasks failed or were
+   abandoned, stop. A majority-failed phase is a systemic fault — a broken suite, a bad
+   plan, a missing dependency — and the next phase will almost certainly hit it too.
+   Under `autonomous`, file an `agent-blocked` issue with the phase status and the
+   failure details.
+
+   c. **Retry budget.** Tasks that exhausted their retries (default 2) are already
+   `abandoned`. Under `autonomous`, file one `agent-blocked` issue per abandoned task
+   rather than one per attempt.
+
+4. **Write a checkpoint** before advancing, so an interrupted run resumes with its
+   reasoning intact (ADR-021):
+
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/lib/task-manifest.sh" --set-checkpoint \
+     --agent-id orchestrator --phase <N> \
+     --summary-text "<what completed, what failed and why, what to do next>"
+   ```
+
+5. **Report and advance.**
+   - `interactive`: report and continue as today.
+   - `supervised`: post a progress summary, then continue automatically unless a stop
+     condition fired.
+   - `autonomous`: update the live progress issue, then continue.
+
+   Return to Stage 2 for the next phase.
 
 ### Stage 5: Completion
 
@@ -191,6 +287,10 @@ For each task in the phase:
    - If all merged: _"Plan \<number\> implementation complete."_
    - If some failed: list failed/abandoned tasks with details
 
+   Never report a halted or circuit-broken run as complete. Say which stop condition
+   fired and what remains — a run that stopped early and a run that finished are
+   different outcomes, and only one of them is done.
+
 2. **Clean up remaining worktrees.** For any worktrees still present:
 
    ```bash
@@ -198,6 +298,21 @@ For each task in the phase:
    ```
 
    Remove worktrees for merged or abandoned tasks.
+
+3. **Autonomous mode only — close the loop.** Before opening anything:
+
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/lib/run-checks.sh"
+   ```
+
+   Then run `/pr-describe`, `/review-checklist`, and `/release-ready`, and open a
+   **draft** PR labelled `agent-authored`, linking the issue, proposal, and plan.
+
+   The draft status and the label are both load-bearing (ADR-022): promotion to
+   ready-for-review is a human act, and the in-flight PR budget is counted by that label,
+   so an unlabelled agent PR is invisible to the review-capacity circuit breaker.
+
+   Never approve, promote, or merge. No mode auto-merges.
 
 ## Error Recovery
 

--- a/scripts/check-cross-plugin-drift.sh
+++ b/scripts/check-cross-plugin-drift.sh
@@ -5,10 +5,10 @@
 # plugin is now impossible rather than merely detected. Cross-plugin sharing is the
 # one case that idea does not cover: ${CLAUDE_PLUGIN_ROOT} resolves to one plugin, and
 # principled-github, principled-quality and principled-release install independently,
-# so a script all three need genuinely has to exist three times.
+# so a script all four need genuinely has to exist four times.
 #
 # That is the entire remaining surface: check-gh-cli.sh, canonical in
-# principled-github/lib/, vendored into the other two. Fifteen copies became three.
+# principled-github/lib/, vendored into the other three. Fifteen copies became four.
 #
 # This replaces three separate per-plugin drift checkers. Consolidating matters: the
 # old per-plugin checkers each carried a hand-maintained list of copies, and at least
@@ -62,6 +62,7 @@ echo ""
 
 compare "$CANONICAL" "plugins/principled-quality/lib/check-gh-cli.sh"
 compare "$CANONICAL" "plugins/principled-release/lib/check-gh-cli.sh"
+compare "$CANONICAL" "plugins/principled-agent/lib/check-gh-cli.sh"
 
 echo ""
 echo "Checked ${CHECKED} file pair(s)."

--- a/tests/agent-governance.bats
+++ b/tests/agent-governance.bats
@@ -1,0 +1,236 @@
+#!/usr/bin/env bats
+# Tests for plugins/principled-agent/lib/agent-governance.sh (ADR-022).
+#
+# These constraints exist for the case where nobody is watching, which is exactly when a
+# silent failure would go unnoticed. Two properties matter more than the rest and are
+# tested hardest:
+#
+#   1. Refusal is distinguishable from error. Exit 3 means "you may not"; exit 1 means
+#      "I could not tell". A caller that conflates them either ignores a real refusal or
+#      halts on a transient fault.
+#   2. Unknown budgets fail CLOSED. If gh cannot be reached, the counts are unknown, and
+#      unknown must never read as headroom — that inversion would silently disable the
+#      whole safety layer precisely when the environment is already misbehaving.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+  LIB="${REPO_ROOT}/plugins/principled-agent/lib/agent-governance.sh"
+  WORK="${BATS_TEST_TMPDIR}/work"
+  mkdir -p "$WORK"
+  cd "$WORK" || return 1
+  git init -q -b main .
+  git config user.email test@example.com
+  git config user.name "Test"
+  git config core.fsmonitor false
+  git config gc.auto 0
+  make_gh_stub
+}
+
+# A stub gh whose counts are driven by environment variables, so budget arithmetic can
+# be tested without a network or a real repository.
+make_gh_stub() {
+  STUB_BIN="${BATS_TEST_TMPDIR}/stub-bin"
+  mkdir -p "$STUB_BIN"
+  cat > "${STUB_BIN}/gh" << 'STUB'
+#!/usr/bin/env bash
+if [ "$1" = "auth" ]; then exit 0; fi
+n=0
+case "$1" in
+  issue) n="${STUB_BLOCKED:-0}" ;;
+  pr) n="${STUB_PRS:-0}" ;;
+esac
+out="["
+i=0
+while [ "$i" -lt "$n" ]; do
+  [ "$i" -gt 0 ] && out="${out},"
+  out="${out}{\"number\":$((i + 1))}"
+  i=$((i + 1))
+done
+echo "${out}]"
+STUB
+  chmod +x "${STUB_BIN}/gh"
+}
+
+with_gh() {
+  PATH="${STUB_BIN}:${PATH}" "$@"
+}
+
+# A PATH with neither gh nor jq, for the degradation tests.
+make_bare_path() {
+  BARE_BIN="${BATS_TEST_TMPDIR}/bare-bin"
+  [[ -d "$BARE_BIN" ]] && return 0
+  mkdir -p "$BARE_BIN"
+  local tool src
+  for tool in bash sh cat grep sed head tail awk tr wc git mkdir rm mv printf env test expr; do
+    src="$(command -v "$tool" 2> /dev/null || true)"
+    [[ -n "$src" ]] && ln -sf "$src" "${BARE_BIN}/${tool}"
+  done
+}
+
+# --- Halt switch ---
+
+@test "no halt reports clear and exits 0" {
+  run bash "$LIB" --check-halt
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "no halt in effect"
+}
+
+@test "engaging the halt writes the reason to .agents/HALT" {
+  bash "$LIB" --halt "CI is broken"
+  [ -f .agents/HALT ]
+  grep -q "CI is broken" .agents/HALT
+}
+
+@test "an engaged halt exits 3 and prints the reason and path" {
+  bash "$LIB" --halt "CI is broken" > /dev/null
+  run bash "$LIB" --check-halt
+  [ "$status" -eq 3 ]
+  echo "$output" | grep -q "HALTED"
+  echo "$output" | grep -q "CI is broken"
+  # A halt nobody can locate is a halt that gets worked around.
+  echo "$output" | grep -q ".agents/HALT"
+}
+
+@test "halting without a reason still records something" {
+  bash "$LIB" --halt > /dev/null
+  [ -s .agents/HALT ]
+  run bash "$LIB" --check-halt
+  [ "$status" -eq 3 ]
+}
+
+@test "resume clears the halt" {
+  bash "$LIB" --halt "temporary" > /dev/null
+  bash "$LIB" --resume
+  [ ! -f .agents/HALT ]
+  run bash "$LIB" --check-halt
+  [ "$status" -eq 0 ]
+}
+
+@test "resume with no halt is a no-op rather than an error" {
+  run bash "$LIB" --resume
+  [ "$status" -eq 0 ]
+}
+
+@test "the halt switch works with no gh and no jq at all" {
+  make_bare_path
+  run env -i "PATH=${BARE_BIN}" "HOME=${HOME}" bash "$LIB" --halt "no tooling"
+  [ "$status" -eq 0 ]
+  run env -i "PATH=${BARE_BIN}" "HOME=${HOME}" bash "$LIB" --check-halt
+  [ "$status" -eq 3 ]
+}
+
+# --- The dispatch gate ---
+
+@test "dispatch is permitted when halted-off and both budgets have room" {
+  run with_gh env STUB_BLOCKED=1 STUB_PRS=2 bash "$LIB" --can-dispatch
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "dispatch permitted"
+}
+
+@test "the halt switch refuses dispatch before any budget is consulted" {
+  bash "$LIB" --halt "stop everything" > /dev/null
+  # Budgets are wide open; the halt must still win.
+  run with_gh env STUB_BLOCKED=0 STUB_PRS=0 bash "$LIB" --can-dispatch
+  [ "$status" -eq 3 ]
+  echo "$output" | grep -q "halt switch engaged"
+}
+
+@test "reaching the blocked-issue budget refuses dispatch" {
+  run with_gh env STUB_BLOCKED=5 STUB_PRS=0 bash "$LIB" --can-dispatch
+  [ "$status" -eq 3 ]
+  echo "$output" | grep -q "agent-blocked issue"
+}
+
+@test "reaching the in-flight PR budget refuses dispatch" {
+  run with_gh env STUB_BLOCKED=0 STUB_PRS=5 bash "$LIB" --can-dispatch
+  [ "$status" -eq 3 ]
+  echo "$output" | grep -q "in-flight agent PR"
+}
+
+@test "the budget boundary is inclusive" {
+  # 4 of 5 proceeds; 5 of 5 refuses. Off-by-one here would let the cap be exceeded.
+  run with_gh env STUB_BLOCKED=4 STUB_PRS=4 bash "$LIB" --can-dispatch
+  [ "$status" -eq 0 ]
+  run with_gh env STUB_BLOCKED=5 STUB_PRS=4 bash "$LIB" --can-dispatch
+  [ "$status" -eq 3 ]
+}
+
+@test "budgets can be raised explicitly" {
+  run with_gh env STUB_BLOCKED=8 STUB_PRS=8 bash "$LIB" --can-dispatch --blocked-budget 10 --pr-budget 10
+  [ "$status" -eq 0 ]
+}
+
+@test "a non-numeric budget is rejected" {
+  run bash "$LIB" --can-dispatch --pr-budget many
+  [ "$status" -eq 1 ]
+}
+
+# --- Failing closed ---
+
+@test "dispatch refuses when budgets cannot be verified" {
+  make_bare_path
+  run env -i "PATH=${BARE_BIN}" "HOME=${HOME}" bash "$LIB" --can-dispatch
+  # Unknown must never read as headroom.
+  [ "$status" -eq 3 ]
+  echo "$output" | grep -q "cannot verify governance budgets"
+}
+
+@test "an unverifiable budget is reported as unknown, not as zero" {
+  make_bare_path
+  run env -i "PATH=${BARE_BIN}" "HOME=${HOME}" bash "$LIB" --status
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "unknown"
+  # Reporting 0 would imply full headroom, inverting the safety property.
+  ! echo "$output" | grep -q "0/5"
+}
+
+@test "refusal (exit 3) is distinguishable from error (exit 1)" {
+  bash "$LIB" --halt "refused" > /dev/null
+  run bash "$LIB" --can-dispatch
+  [ "$status" -eq 3 ]
+  run bash "$LIB" --bogus-operation
+  [ "$status" -eq 1 ]
+}
+
+# --- Status reporting ---
+
+@test "status reports halt state and both budgets" {
+  run with_gh env STUB_BLOCKED=2 STUB_PRS=1 bash "$LIB" --status
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "2/5"
+  echo "$output" | grep -q "1/5"
+}
+
+@test "status json is valid and carries null for unknown counts" {
+  make_bare_path
+  run env -i "PATH=${BARE_BIN}" "HOME=${HOME}" bash "$LIB" --status --format json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.agent_blocked_issues == null' > /dev/null
+  echo "$output" | jq -e '.in_flight_prs == null' > /dev/null
+}
+
+@test "status json escapes a halt reason containing quotes" {
+  bash "$LIB" --halt 'the "test suite" broke' > /dev/null
+  run with_gh env STUB_BLOCKED=0 STUB_PRS=0 bash "$LIB" --status --format json
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.halted == true' > /dev/null
+  echo "$output" | jq -e '.halt_reason | contains("test suite")' > /dev/null
+}
+
+@test "counts work without jq, via the grep fallback" {
+  make_bare_path
+  # gh present, jq absent: the fallback counts JSON objects with grep.
+  run env -i "PATH=${STUB_BIN}:${BARE_BIN}" "HOME=${HOME}" STUB_BLOCKED=3 bash "$LIB" --count-blocked
+  [ "$status" -eq 0 ]
+  [ "$output" = "3" ]
+}
+
+@test "unknown format is rejected" {
+  run bash "$LIB" --status --format yaml
+  [ "$status" -eq 1 ]
+}
+
+@test "no operation exits non-zero with usage" {
+  run bash "$LIB"
+  [ "$status" -eq 1 ]
+}

--- a/tests/hooks.bats
+++ b/tests/hooks.bats
@@ -447,3 +447,72 @@ run_without_jq() {
     "{\"tool_input\":{\"file_path\":\"${mem}\"}}"
   [ "$status" -eq 0 ]
 }
+
+# --- Agent governance advisory (principled-agent) ---
+#
+# Advisory by construction: PostToolUse fires after the command has already run, so
+# blocking here would be theatre. The authoritative enforcement is --can-dispatch
+# before a run starts, and branch protection on the GitHub side.
+
+@test "governance advisory warns on a non-draft PR create" {
+  run bash -c "echo '{\"tool_input\":{\"command\":\"gh pr create --title x --label agent-authored\"}}' | bash '${AGENT_HOOKS}/check-agent-governance.sh' 2>&1"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'draft'
+}
+
+@test "governance advisory stays quiet on a compliant draft PR" {
+  run bash -c "echo '{\"tool_input\":{\"command\":\"gh pr create --draft --title x --label agent-authored\"}}' | bash '${AGENT_HOOKS}/check-agent-governance.sh' 2>&1"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "governance advisory warns when an agent PR lacks the agent-authored label" {
+  run bash -c "echo '{\"tool_input\":{\"command\":\"gh pr create --draft --title x\"}}' | bash '${AGENT_HOOKS}/check-agent-governance.sh' 2>&1"
+  [ "$status" -eq 0 ]
+  # An unlabelled agent PR is invisible to the in-flight budget.
+  echo "$output" | grep -q 'agent-authored'
+}
+
+@test "governance advisory warns on self-approval" {
+  run bash -c "echo '{\"tool_input\":{\"command\":\"gh pr review 42 --approve\"}}' | bash '${AGENT_HOOKS}/check-agent-governance.sh' 2>&1"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'must not approve'
+}
+
+@test "governance advisory warns on merge and on ready-for-review promotion" {
+  run bash -c "echo '{\"tool_input\":{\"command\":\"gh pr merge 42\"}}' | bash '${AGENT_HOOKS}/check-agent-governance.sh' 2>&1"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'auto-merge'
+  run bash -c "echo '{\"tool_input\":{\"command\":\"gh pr ready 42\"}}' | bash '${AGENT_HOOKS}/check-agent-governance.sh' 2>&1"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'human decision'
+}
+
+@test "governance advisory surfaces an engaged halt on a dispatch command" {
+  make_agents_repo
+  printf 'CI is broken\n' > "${AGENT_REPO}/.agents/HALT"
+  run bash -c "cd '${AGENT_REPO}' && echo '{\"tool_input\":{\"command\":\"bash agent-dispatch.sh 12\"}}' | bash '${AGENT_HOOKS}/check-agent-governance.sh' 2>&1"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'halt switch is engaged'
+  echo "$output" | grep -q 'CI is broken'
+}
+
+@test "governance advisory ignores unrelated commands" {
+  run bash -c "echo '{\"tool_input\":{\"command\":\"ls -la\"}}' | bash '${AGENT_HOOKS}/check-agent-governance.sh' 2>&1"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "governance advisory never blocks and survives malformed input" {
+  run bash -c "echo 'not json' | bash '${AGENT_HOOKS}/check-agent-governance.sh'"
+  [ "$status" -eq 0 ]
+  run bash -c "echo '' | bash '${AGENT_HOOKS}/check-agent-governance.sh'"
+  [ "$status" -eq 0 ]
+}
+
+@test "governance advisory works without jq" {
+  run run_without_jq "${AGENT_HOOKS}/check-agent-governance.sh" \
+    '{"tool_input":{"command":"gh pr create --title x"}}'
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'draft'
+}


### PR DESCRIPTION
> **Stacked on #32.** Base is `feat/rfc-011-agent-memory-and-resumability`, so this diff shows only the RFC-012 work. Merge #32 first; this will retarget to `main` automatically.

Implements [RFC-012](docs/proposals/012-github-native-agent-collaboration.md), accepted here with its four open questions resolved.

## Resolved questions

| Question | Answer |
|---|---|
| Where do execution modes live? | `--mode` stays in `/orchestrate`. Mode asks *how much human involvement*; dispatch asks *which agent, and may it start* |
| How is `agent-blocked` triaged? | A budget (default 5) that **halts dispatch** — blockers outpacing triage is systemic, not queue depth |
| Concurrency ceiling? | **Review capacity binds, not CI.** Cap sits on in-flight PRs (5), not workers (3) |
| Kill switch? | Required, file-based, checked everywhere |

## The organizing principle

The autonomy modes exist for the case where **nobody is watching**, so "the agent should check" is unfalsifiable exactly when it matters most. Every constraint that matters is therefore enforced by something a script can answer, not by protocol prose (ADR-022).

## Two safety properties worth reviewing closely

**Exit 3 means refused; exit 1 means could not tell.** A caller that conflates them either ignores a real refusal or halts on a transient fault.

**Unknown budgets fail closed.** When `gh` is unreachable the counts are unknown and dispatch *refuses*. Treating unknown as zero would read as full headroom and silently disable the entire safety layer at exactly the moment the environment is already misbehaving. `tests/agent-governance.bats` asserts `--status` never prints `0/5` for an unknown count.

## Dispatch ships deliberately disarmed

Per ADR-023, the workflow is a **template**, not an active workflow:

- absent from `.github/workflows/` in this repo
- defaults to `workflow_dispatch` only; the `issues` trigger is present but **commented**
- requests only `contents` / `issues` / `pull-requests` write — no `actions: write`, so a compromised run cannot rewrite its own dispatcher

Installing a plugin should not arm anything, and `--local` makes the whole infrastructure layer optional. **If you'd rather this be live here, that's a one-file copy plus a secret — but it seemed like your call, not something to inherit from a merge.**

## Also corrected

`docs/architecture/plugin-system.md` still asserted ADR-009's *"scripts have no shared directory"* rule that ADR-018 superseded. Replaced with the `lib/` constraint, plus a new section documenting the cross-plugin file-path contract — including the uncomfortable part: **those couplings are invisible to `check-skill-references.sh`** and survive only by convention.

## Verification

`just ci` green — **158 bats tests, up from 126**. Template claims verified by parsing the YAML: one trigger, three permissions, `actions: write` only in a comment.

**Not exercised: the end-to-end protocol has never been run.** No issue dispatched, no agent PR opened. The caps (5 blockers, 5 PRs, 3 workers, 2 retries) are conservative defaults, recorded as such rather than dressed up as measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKzFURKGfB1Ec3ayH2hjE2