### PR TITLE
chore: accept ADR-015/016/019, bump marketplace to 0.5.0, fix stale docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "principled-marketplace",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Curated marketplace for Principled methodology Claude Code plugins. First-party and community plugins for specification-first development.",
   "owner": {
     "name": "Alex Nodeland"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ core
 
 ## What This Is
 
-This repo is the **Principled methodology plugin marketplace** (v0.4.0, pre-1.0). It hosts Claude Code plugins for specification-first development, organized as a curated directory with two tiers: first-party plugins in `plugins/` and community plugins in `external_plugins/`. Eight first-party plugins ship today:
+This repo is the **Principled methodology plugin marketplace** (v0.5.0, pre-1.0). It hosts Claude Code plugins for specification-first development, organized as a curated directory with two tiers: first-party plugins in `plugins/` and community plugins in `external_plugins/`. Eight first-party plugins ship today:
 
 - **principled-docs** (v0.3.1) — Scaffold, author, and enforce module documentation structure for monorepos.
 - **principled-implementation** (v0.1.0) — Orchestrate DDD plan execution via worktree-isolated Claude Code agents.
@@ -32,7 +32,7 @@ Eleven layers, top to bottom:
 | **Release: All**        | `plugins/principled-release/`                                      | Skills (6), hooks (1) for release lifecycle: changelogs, readiness, version bumps, tagging                           |
 | **Architecture: All**   | `plugins/principled-architecture/`                                 | Skills (6), hooks (1), agents (1) for architecture governance: mapping, drift detection, auditing, sync              |
 | **Tasks: All**          | `plugins/principled-tasks/`                                        | Skills (7), 1 hook, and `lib/task-db.sh` for the event-log task graph: open, close, update, query, audit, visualize  |
-| **Agent: All**          | `plugins/principled-agent/`                                        | Skills (4), 2 hooks, and `lib/agent-memory.sh` for `.agents/` identity, memory injection, and integrity              |
+| **Agent: All**          | `plugins/principled-agent/`                                        | Skills (7), 3 hooks, `lib/agent-memory.sh` and `lib/agent-governance.sh` for identity, memory, and the dispatch gate |
 | **Dev DX**              | `.claude/`, config files, `.github/workflows/`                     | Project-level Claude Code settings, dev skills, CI pipeline, linting config                                          |
 
 ## Skills
@@ -60,7 +60,7 @@ Eleven layers, top to bottom:
 | `spawn`         | `/spawn <task-id>`                                     | Orchestration |
 | `check-impl`    | `/check-impl [--task <id>] [--all]`                    | Analytical    |
 | `merge-work`    | `/merge-work <task-id> [--force] [--no-cleanup]`       | Orchestration |
-| `orchestrate`   | `/orchestrate <plan-path> [--phase N] [--continue]`    | Orchestration |
+| `orchestrate`   | `/orchestrate <plan-path> [--mode M] [--continue]`     | Orchestration |
 | `resume`        | `/resume [<plan-path>] [--from-checkpoint] [--replan]` | Orchestration |
 
 ### principled-github (9 skills)
@@ -262,9 +262,12 @@ major bump.
 
 The marketplace previously read `1.0.0` while every plugin sat at `0.1.0`. That was
 not a defensible claim: the first automated tests landed in July 2026 and immediately
-surfaced correctness bugs in shipped skills, and two of the governing ADRs (017, 018)
-are still `proposed`. `0.4.0` reflects a catalog of seven plugins that works and is
-still moving.
+surfaced correctness bugs in shipped skills. `0.5.0` reflects a catalog of eight
+plugins that works and is still moving.
+
+Every ADR is now `accepted` — 015, 016 and 019 were ratified once the code they
+describe had shipped and was under test. That removes one of the two barriers to 1.0;
+the interfaces are the other, and they are still changing.
 
 Reach 1.0 per plugin when its interface has stopped changing, it has test coverage,
 and its governing ADRs are `accepted`.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/claude_code-v2.1.3+-7c3aed?style=flat-square" alt="Claude Code v2.1.3+" />
-  <img src="https://img.shields.io/badge/marketplace-v0.4.0-blue?style=flat-square" alt="Marketplace v0.4.0" />
+  <img src="https://img.shields.io/badge/marketplace-v0.5.0-blue?style=flat-square" alt="Marketplace v0.5.0" />
   <img src="https://img.shields.io/badge/license-MIT-gray?style=flat-square" alt="License: MIT" />
 </p>
 

--- a/docs/architecture/agent-collaboration.md
+++ b/docs/architecture/agent-collaboration.md
@@ -166,7 +166,8 @@ it dilutes context forever without preventing anything.
   blockers mean none.
 - **The template is not exercised by CI.** The reference checker confirms it exists, not
   that it runs, so it can rot undetected.
-- **The four-role parallel model needs agent teams** (ADR-016, still `proposed`). Roles
+- **The four-role parallel model needs agent teams** (ADR-016), which remain behind
+  the `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` flag. Roles
   are documented as a coordination pattern over shipped skills; no code requires teams.
 - **A stale `.agents/HALT` blocks everything.** Every refusal prints the reason and the
   path, so the cause is never a mystery — but nothing expires it.

--- a/docs/decisions/015-event-driven-lifecycle-hooks.md
+++ b/docs/decisions/015-event-driven-lifecycle-hooks.md
@@ -1,7 +1,8 @@
 ---
 title: "Event-Driven Lifecycle Hooks for Pipeline Enforcement"
 number: "015"
-status: proposed
+status: accepted
+updated: 2026-07-28
 author: Alex
 created: 2026-02-23
 originating_proposal: "008"
@@ -12,7 +13,7 @@ superseded_by: null
 
 ## Status
 
-Proposed
+Accepted
 
 <!-- Valid values: proposed, accepted, deprecated, superseded -->
 <!-- Once accepted, this document is IMMUTABLE. -->

--- a/docs/decisions/016-agent-teams-for-parallel-execution.md
+++ b/docs/decisions/016-agent-teams-for-parallel-execution.md
@@ -1,7 +1,8 @@
 ---
 title: "Agent Teams for Parallel Plan Execution"
 number: "016"
-status: proposed
+status: accepted
+updated: 2026-07-28
 author: Alex
 created: 2026-02-23
 originating_proposal: "008"
@@ -12,7 +13,7 @@ superseded_by: null
 
 ## Status
 
-Proposed
+Accepted
 
 <!-- Valid values: proposed, accepted, deprecated, superseded -->
 <!-- Once accepted, this document is IMMUTABLE. -->

--- a/docs/decisions/019-bats-for-shell-testing.md
+++ b/docs/decisions/019-bats-for-shell-testing.md
@@ -1,7 +1,7 @@
 ---
 title: "Bats for Shell Testing"
 number: "019"
-status: proposed
+status: accepted
 author: Alex
 created: 2026-07-28
 updated: 2026-07-28
@@ -14,7 +14,7 @@ superseded_by: null
 
 ## Status
 
-Proposed
+Accepted
 
 <!-- Valid values: proposed, accepted, deprecated, superseded -->
 <!-- Once accepted, this document is IMMUTABLE. -->


### PR DESCRIPTION
Housekeeping that closes the gap between what the docs assert and what is true.

## Accepting the three remaining `proposed` ADRs

Each describes code that has shipped and is under test. I verified before flipping rather than rubber-stamping:

| ADR | Verified |
|---|---|
| **015** lifecycle hooks | All four events (`WorktreeCreate`, `WorktreeRemove`, `SubagentStop`, `TaskCompleted`) wired in `hooks.json`, scripts present; `SubagentStart` joined them in principled-agent |
| **016** agent teams | Referenced by `/orchestrate`, the orchestration guide, and `gate-task-completion.sh` |
| **019** bats | 158 tests across five files, run by CI on both Ubuntu and macOS bash 3.2 |

Every ADR is now `accepted`. That removes one of the two barriers to 1.0 that CLAUDE.md names — interfaces are the other, and they're still moving.

## Marketplace 0.4.0 → 0.5.0

The marketplace version tracks the catalog, and the catalog gained an eighth plugin (principled-agent). Plugin versions are unchanged.

## Two stale claims fixed

While checking, I found the architecture layer table still advertising principled-agent as **4 skills and 2 hooks** (it's 7 and 3), and the skills table still showing `/orchestrate` without `--mode`.

Both were string-replaces in the RFC-012 pass that **silently no-opped** because prettier had reformatted the table column widths between when I wrote the row and when I replaced it. A no-op replace fails silently, which is exactly how this survived CI.

So rather than fix the two and move on, I verified *every* documented skill and hook count against the filesystem and `hooks.json`:

```
PLUGIN                        SKILLS   HOOKS
principled-agent                   7       3   ← was documented as 4 / 2
principled-architecture            6       1
principled-docs                    9       8
principled-github                  9       1
principled-implementation          7       5
principled-quality                 5       1
principled-release                 6       1
principled-tasks                   7       1
```

All now match. Test counts also confirmed: `hooks.bats` is 57, total is 158.

`just ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKzFURKGfB1Ec3ayH2hjE2