### PR TITLE
feat: verify cross-plugin file-path contracts (RFC-014, Plan-012)

### DIFF
--- a/.agents/memory/agents/impl-worker.md
+++ b/.agents/memory/agents/impl-worker.md
@@ -2,9 +2,9 @@
 agent_id: "impl-worker"
 role: worker
 last_updated: 2026-07-28
-session_count: 0
-total_tasks: 0
-success_rate: 0.0
+session_count: 1
+total_tasks: 4
+success_rate: 1.00
 specializations: []
 ---
 
@@ -12,8 +12,20 @@ specializations: []
 
 ## Known Patterns
 
-<!-- Durable facts about this codebase that this agent should not relearn. -->
+- A `.md` reference is functional coupling here, not documentation: a SKILL.md
+  instructing the model to read a path _is_ the read. Scoping a search to `.sh` misses
+  the real readers.
+- Prettier reflows markdown table column widths whenever a cell's length changes. Parse
+  tables by cell content, never by column position — and never trust a string-replace
+  against a table row to have applied, because a no-op replace fails silently.
 
 ## Pitfalls
 
-<!-- Mistakes made before, and what to do instead. -->
+- Do not build JSON test payloads with `echo`: zsh expands `\n` and corrupts them, and a
+  hook that appears to "allow" may simply have received garbage. Use
+  `python3 -c 'json.dumps'` into a file.
+- A `case " $list " in *" $item "*)` membership test needs **space** separators. `sort -u`
+  and `grep -o` emit newlines, so the glob silently never matches. Normalize with
+  `tr '\n' ' '` first.
+- Never use `sed -i` — BSD sed reads the next argument as a backup suffix, so the same
+  invocation behaves differently on macOS and Linux. Use `awk` into a temp file and `mv`.

--- a/.agents/retrospectives/2026-07-28-issue-36.md
+++ b/.agents/retrospectives/2026-07-28-issue-36.md
@@ -1,0 +1,83 @@
+---
+date: 2026-07-28
+issue: "36"
+plan: "012"
+proposal: "014"
+agent: impl-worker
+mode: local
+tasks_total: 4
+tasks_merged: 4
+tasks_failed: 0
+---
+
+# Retrospective — Issue #36, the first protocol run
+
+The first end-to-end exercise of the Agent Contributor Protocol (RFC-012), run with
+`/agent-dispatch 36 --local`. The work itself — verifying cross-plugin file-path
+contracts — was chosen because it was a real gap the repository had documented against
+itself, not because it was convenient to demonstrate.
+
+## What happened
+
+Gate → issue → RFC-014 → human approval → Plan-012 → implementation → 170 tests green.
+Four phases, none failed, no retries, no blockers filed.
+
+## What worked
+
+**The governance gate ran for real.** `--can-dispatch` queried the live GitHub API and
+reported `0/5` blockers and `0/5` in-flight PRs before anything else happened. It was not
+a stub, and it was consulted first as designed.
+
+**The human gate held.** The protocol stopped at proposal approval and did not proceed on
+silence. That is the property the whole design rests on, and it behaved.
+
+**The check found something on its first run.** `.impl/manifest.json` was declared as read
+only by principled-agent; it is also read by principled-github, in code. Real coupling,
+undocumented, invisible to every other check in CI.
+
+## What failed, and why
+
+**Routing is nominal.** `/agent-dispatch` selects an agent by `specializations` from the
+registry. Every agent's is `[]` — the scaffold seeds them empty and nothing populates
+them. Selecting `impl-worker` was a fallback dressed as a decision. The feature does not
+work; it merely does not error.
+
+**`/ingest-issue`'s "Plan only" branch is unreachable.** The skill offers it for
+well-scoped work where the approach is clear, which described #36 exactly. But
+`check-plan-proposal-link.sh` blocks any plan whose `originating_proposal` is missing or
+null (verified: exit 2). Every dispatched issue must therefore produce an RFC regardless
+of size. Writing a full RFC to justify a CI-check improvement is the friction that falls
+out of that, and the classification branch is dead code.
+
+**I shipped a bug in the check and the repository's own shape caught it.** The first
+implementation reported every reader on a multi-reader row as undeclared: readers were
+newline-separated while the membership test globbed against `" $readers "`. Single-reader
+rows passed and hid it. Only the three-reader manifest row exposed it.
+
+**A false alarm from a bad harness.** I briefly concluded the plan-proposal guard was
+broken because a test showed it allowing. It was not: `echo` under zsh expanded `\n` and
+corrupted the JSON, so the guard correctly failed open on unparseable input. Retested with
+`python3 -c json.dumps`, it blocked properly.
+
+## Durable learnings
+
+Candidates for memory. Each is a fact about this codebase rather than about this run.
+
+- Building JSON test payloads with `echo` is unsafe under zsh, which expands `\n` and
+  silently corrupts them. A hook that "allows" may simply have received garbage. Build
+  payloads with `python3 -c 'json.dumps'` and write them to a file.
+- In bash, a `case " $list " in *" $item "*)` membership test requires **space**
+  separators. `sort -u` and `grep -o` produce newlines, so the glob silently never
+  matches. Normalize with `tr '\n' ' '` before testing membership.
+- Prettier reflows markdown table column widths whenever a cell's length changes. Any
+  parser over a table must key on cell **content**, never on column position — and any
+  string-replace against a table row can silently no-op after a reformat.
+- A `.md` reference is functional coupling here, not documentation: a SKILL.md instructing
+  the model to read a path _is_ the read. Scoping a search to `.sh` would have missed both
+  readers of `.agents/HALT`.
+
+## Not promoted
+
+- "task-2b failed twice" style facts — there were none; the run had no failures.
+- The routing and "Plan only" findings are defects in this repository, not knowledge an
+  agent should carry. They belong in issues, filed below.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -430,7 +430,7 @@ Declared in `plugins/principled-agent/hooks/hooks.json`:
 - **Template drift (docs):** `plugins/principled-docs/skills/scaffold/scripts/check-template-drift.sh` — exits non-zero if any copy diverges from canonical.
 - **Cross-plugin drift:** `scripts/check-cross-plugin-drift.sh` — exits non-zero if a vendored `check-gh-cli.sh` diverges from canonical.
 - **Pipeline audit:** `scripts/pipeline-audit.sh` — reconciles declared document state against the repository (numbering, plan/proposal links, statuses, supersession chains).
-- **Reference integrity:** `scripts/check-skill-references.sh` — exits non-zero if any script or template referenced by a SKILL.md or hooks.json does not exist.
+- **Reference integrity:** `scripts/check-skill-references.sh` — exits non-zero if any script or template referenced by a SKILL.md or hooks.json does not exist, and verifies the cross-plugin file-path contracts declared in `docs/architecture/plugin-system.md` (writer present, readers agree on the literal, no undeclared readers). Compares strings, not behaviour.
 - **Tests:** `npx bats tests/` — bats suite covering the task graph library, agent memory, agent governance, the manifest checkpoint and criteria, and every hook. Also run on macOS bash 3.2 in CI.
 - **Structure validation:** `plugins/principled-docs/lib/validate-structure.sh --module-path <path> [--type <type>] [--strict] [--json]` — checks a module's docs structure.
 - **Root validation:** `plugins/principled-docs/lib/validate-structure.sh --root` — checks repo-level docs structure.

--- a/docs/architecture/plugin-system.md
+++ b/docs/architecture/plugin-system.md
@@ -192,17 +192,26 @@ Constraint 3 means two plugins that must cooperate cannot call each other. Where
 cooperation is genuinely required, the coupling is a **committed file at a fixed
 repository-root path**, which both read independently:
 
-| Path                      | Written by                | Read by                                       |
-| ------------------------- | ------------------------- | --------------------------------------------- |
-| `.agents/`                | principled-agent          | any plugin; injected at spawn (ADR-020)       |
-| `.agents/HALT`            | principled-agent          | principled-implementation at phase boundaries |
-| `.impl/manifest.json`     | principled-implementation | principled-agent, read-only (ADR-021)         |
-| `.principled/tasks.jsonl` | principled-tasks          | any plugin, read-only (ADR-017)               |
+| Path                      | Written by                | Read by                                                                         |
+| ------------------------- | ------------------------- | ------------------------------------------------------------------------------- |
+| `.agents/`                | principled-agent          | any plugin; injected at spawn (ADR-020)                                         |
+| `.agents/HALT`            | principled-agent          | principled-implementation at phase boundaries                                   |
+| `.impl/manifest.json`     | principled-implementation | principled-agent, principled-github, principled-tasks — all read-only (ADR-021) |
+| `.principled/tasks.jsonl` | principled-tasks          | any plugin, read-only (ADR-017)                                                 |
 
 This is the only mechanism available, and for the halt switch it is also the right one:
 the switch must be operable by a human with no running session (ADR-022).
 
-The cost is real — **these couplings are invisible to `check-skill-references.sh`**,
-which validates `${CLAUDE_PLUGIN_ROOT}` paths and cannot see a bare path in prose. They
-are maintained by convention, so changing one of these paths means finding every reader
-by hand.
+**This table is a declaration of record, not documentation.**
+`scripts/check-skill-references.sh` parses it and verifies, for every row, that the
+named writer references the literal path, that every named reader uses the same string,
+and that no undeclared plugin reads it. A rename that would silently disable the halt
+switch now fails CI (RFC-014).
+
+Two consequences follow. The table's **format is load-bearing** — rows are keyed on the
+backticked path in the first cell, so that cell must stay backticked. And adding a
+cross-plugin read means adding a row; the check will otherwise fail on the undeclared
+coupling, which is the point.
+
+What it does _not_ prove: the check compares literal strings. A green result means the
+declaration matches the code, not that the halt logic works.

--- a/docs/plans/012-verifying-cross-plugin-contracts.md
+++ b/docs/plans/012-verifying-cross-plugin-contracts.md
@@ -1,0 +1,144 @@
+---
+title: "Verifying Cross-Plugin File-Path Contracts"
+number: "012"
+status: complete
+author: Alex
+created: 2026-07-28
+updated: 2026-07-28
+originating_proposal: "014"
+related_adrs: ["018", "022"]
+---
+
+<!-- principled-ingested-from: #36 -->
+
+# Plan-012: Verifying Cross-Plugin File-Path Contracts
+
+## Objective
+
+Implements [RFC-014](../proposals/014-verifying-cross-plugin-contracts.md), closing
+[#36](https://github.com/alexnodeland/principled/issues/36).
+
+Make the cross-plugin contract table in `docs/architecture/plugin-system.md` normative:
+parse it, verify every declared path has a writer and consistent readers, and fail CI when
+a rename would silently disable the halt switch.
+
+## Related Decisions
+
+- [ADR-018](../decisions/018-shared-plugin-lib-over-copies.md) — plugins install
+  independently and cannot reference each other's `${CLAUDE_PLUGIN_ROOT}`, which is _why_
+  these bare-path contracts exist at all
+- [ADR-022](../decisions/022-agent-governance-constraints.md) — the halt switch is the
+  load-bearing contract; a silent break defeats its purpose
+
+## Domain Analysis
+
+### Bounded Contexts
+
+**Contract Declaration** (`docs/architecture/plugin-system.md`) — the table is the source
+of truth. RFC-014 chose to parse it rather than duplicate it into JSON, so its format
+becomes load-bearing.
+
+**Contract Verification** (`scripts/check-skill-references.sh`) — extends the existing
+"references resolve" check rather than adding a sibling, so `just refs` stays one command
+and a failure has one home.
+
+### Aggregates
+
+| Aggregate    | Root                               | Invariants                                             |
+| ------------ | ---------------------------------- | ------------------------------------------------------ |
+| Contract row | a table row in `plugin-system.md`  | Path, writer plugin, reader plugins all present        |
+| Path usage   | literal string in a plugin's files | Writer references it; every declared reader matches it |
+
+### Domain Events
+
+- **ContractDeclared** → a row is added to the table
+- **ContractViolated** → a declared path has no writer, or readers disagree on the literal
+- **UndeclaredCoupling** → a plugin references another's state path with no table row
+
+## Implementation Tasks
+
+### Phase 1: Parse the declaration
+
+- [x] Extract the contract table from `docs/architecture/plugin-system.md`, keyed on the
+      backticked path in the first cell rather than on column position, so a prettier
+      reformat does not break it
+- [x] Map the writer and reader cells to plugin directory names, tolerating the prose that
+      appears alongside them ("at phase boundaries", "read-only", "any plugin")
+- [x] Fail loudly if the table is missing or unparseable — a silently skipped check is the
+      failure mode this plan exists to remove
+
+### Phase 2: Verify usage
+
+- [x] For each contract path, confirm at least one file in the writing plugin contains the
+      literal string
+- [x] Confirm every named reader plugin contains the same literal string; treat "any
+      plugin" as no reader requirement
+- [x] Report each result in the existing output style, and make clear the check compares
+      strings rather than proving the halt logic works (RFC-014's stated risk)
+
+### Phase 3: Tests and integration
+
+- [x] `tests/contract-verification.bats` — a renamed path fails, a missing writer fails, a
+      reader typo fails, and the real repository passes
+- [x] Confirm `just refs` and the CI job pick it up with no workflow change
+- [x] ShellCheck and shfmt clean; bash 3.2 compatible; jq not required
+
+### Phase 4: Documentation
+
+- [x] Note in `plugin-system.md` that the table is verified, and that its format matters
+- [x] Update `CLAUDE.md` § Testing to describe the new check
+
+## Dependencies
+
+All shipped. No new tooling, no new CI step, no `jq` requirement.
+
+## Acceptance Criteria
+
+- [x] Renaming `.agents/HALT` in principled-agent fails CI
+- [x] A reader referencing a different literal fails CI
+- [x] All three declared contracts pass against the repository as it stands
+- [x] The check runs inside `just refs` with no workflow change
+- [x] Output states plainly that it verifies strings, not behaviour
+- [x] ShellCheck and shfmt clean, bash 3.2 compatible
+- [x] `just ci` passes
+
+## Verification
+
+`just ci` green — 170 bats tests, up from 158. `tests/contract-verification.bats` (12
+tests) copies the repository into a temp directory and mutates the copy, so the failure
+cases are constructed rather than asserted:
+
+- renaming `.agents/HALT` in the writer fails
+- a reader drifting to `.agents/halt` fails
+- an undeclared cross-plugin reader fails
+- a contract naming a nonexistent plugin fails
+- a missing table fails loudly rather than passing vacuously
+- reflowing the table columns does **not** break the parser (prettier reflowed this very
+  table during the run, which exercised it for real)
+
+The acceptance criterion said "all three declared contracts pass". There are four —
+`.agents/` was in the table and the criterion undercounted it. All four pass.
+
+## What the check found immediately
+
+`.impl/manifest.json` was declared as read only by principled-agent. It is also read by
+**principled-github** — `pr-describe/scripts/task-manifest.sh` opens the file directly —
+and referenced by principled-tasks' `task-model.md`. Real coupling, undocumented. The
+table now declares all three readers.
+
+That is the check earning its place on its first run: the gap it found was not
+hypothetical, and nothing else in CI could have surfaced it.
+
+## A bug in the check itself
+
+The first implementation reported every reader on a multi-reader row as undeclared.
+`declared_readers` was newline-separated while the membership test was a glob against
+`" $declared_readers "`, so a newline never matched. The single-reader rows passed and
+masked it; the three-reader manifest row exposed it. Fixed by normalizing to
+space-separated, and pinned by the "multi-reader row" test.
+
+## Limits, stated plainly
+
+The check compares **literal strings**. A green result means the declaration matches the
+code — not that the halt logic works. A path assembled at runtime (`"${dir}/HALT"`) is
+invisible to it, which constrains how these paths may be written.

--- a/docs/proposals/014-verifying-cross-plugin-contracts.md
+++ b/docs/proposals/014-verifying-cross-plugin-contracts.md
@@ -1,0 +1,149 @@
+---
+title: "Verifying Cross-Plugin File-Path Contracts"
+number: "014"
+status: draft
+author: Alex
+created: 2026-07-28
+updated: 2026-07-28
+supersedes: null
+superseded_by: null
+---
+
+<!-- principled-ingested-from: #36 -->
+
+# RFC-014: Verifying Cross-Plugin File-Path Contracts
+
+## Audience
+
+- Maintainers of any plugin that reads or writes state another plugin owns
+- Anyone relying on the halt switch to stop an unattended run
+- Reviewers deciding whether a path rename is safe
+
+## Context
+
+Ingested from [#36](https://github.com/alexnodeland/principled/issues/36).
+
+`scripts/check-skill-references.sh` validates every `${CLAUDE_PLUGIN_ROOT}` path referenced
+by a SKILL.md or hooks.json, and requires that references use that variable rather than a
+bare relative path. That covers intra-plugin dependencies well — it is what caught
+`spawn/SKILL.md` invoking a `parse-plan.sh` that had never been copied.
+
+It cannot see the other class of dependency this repository now depends on.
+
+### The gap
+
+Plugins install independently, and `${CLAUDE_PLUGIN_ROOT}` resolves to exactly one plugin
+(ADR-018). Where two plugins must cooperate, the only available coupling is a bare path at
+the repository root:
+
+| Path                      | Written by                | Read by                                        |
+| ------------------------- | ------------------------- | ---------------------------------------------- |
+| `.agents/HALT`            | principled-agent          | principled-implementation, at phase boundaries |
+| `.impl/manifest.json`     | principled-implementation | principled-agent, read-only                    |
+| `.principled/tasks.jsonl` | principled-tasks          | any plugin, read-only                          |
+
+`docs/architecture/plugin-system.md` documents these and states plainly that they "are
+invisible to `check-skill-references.sh` … and must be maintained by convention."
+
+### Why this one matters more than it looks
+
+The halt switch is the load-bearing case. `/orchestrate` stops at a phase boundary by
+testing for `.agents/HALT` — a path it learns from prose, not from a checked reference.
+
+If principled-agent renames or moves that file, **the kill switch silently stops
+working**. No test fails, no reference breaks, and `/orchestrate` simply never halts. The
+failure is invisible until someone needs to stop a runaway run and discovers they cannot,
+which is precisely the scenario ADR-022 exists to prevent.
+
+A convention that fails silently, guarding a mechanism whose entire purpose is to work
+when things are going wrong, is not a convention worth keeping unverified.
+
+## Proposal
+
+Treat the contract table in `plugin-system.md` as a **declaration of record**, and verify
+it in CI.
+
+### 1. A machine-readable declaration
+
+Parse the existing markdown table rather than introducing a second source of truth. The
+table already exists, is already reviewed, and duplicating it into JSON would create
+exactly the drift this repository has spent two ADRs eliminating.
+
+### 2. What gets checked
+
+For each declared contract path:
+
+- **The writer exists.** At least one script in the named writing plugin references the
+  literal path. A contract with no writer is either stale or a typo.
+- **Readers agree on the literal path.** Every plugin named as a reader references the same
+  string. A reader looking for `.agents/halt` while the writer creates `.agents/HALT` is
+  the exact failure this is for.
+- **No undeclared cross-plugin reads.** A plugin referencing another plugin's state path
+  without a table entry is flagged, so the documentation cannot silently fall behind.
+
+### 3. Where it lives
+
+Extend `scripts/check-skill-references.sh` rather than adding a sibling script. It already
+owns "references resolve" and runs in `just refs`; splitting the two halves would mean two
+scripts, two CI steps, and a new question about which one a given failure belongs to.
+
+## Alternatives Considered
+
+### Alternative 1: A separate JSON manifest of contracts
+
+Trivial to parse and unambiguous. Rejected because it duplicates the table in
+`plugin-system.md`, and a duplicated declaration drifts — the precise problem ADR-018
+solved by deleting copies rather than checking them.
+
+### Alternative 2: Constants in each plugin's `lib/`
+
+Each plugin exports its paths; readers source the writer's constants. Rejected outright:
+it requires exactly the cross-plugin `${CLAUDE_PLUGIN_ROOT}` reference that ADR-018
+establishes is impossible.
+
+### Alternative 3: Integration tests that exercise the halt switch end to end
+
+Highest fidelity — a renamed path fails a real test. Rejected as insufficient _alone_: it
+would need a full orchestration run per contract, which is slow and requires agent
+execution in CI. Worth doing later for the halt switch specifically; not the general
+mechanism.
+
+### Alternative 4: Accept the risk and document it
+
+What we do today. Rejected because the documentation already admits the gap, and the
+cost of closing it is one parser against a table that already exists.
+
+## Consequences
+
+### Positive
+
+- A renamed or moved contract path fails CI instead of silently disabling the halt switch
+- The `plugin-system.md` table stops being decorative and becomes enforced
+- Undeclared cross-plugin coupling surfaces at review time
+- No new dependency, no second source of truth, no new CI step
+
+### Negative
+
+- Parsing a markdown table is brittle in a way parsing JSON is not; a reformat could break
+  the parser. Mitigated by matching on the path cells rather than on column positions
+- Only literal-string references are detectable. A path assembled at runtime
+  (`"${dir}/HALT"`) is invisible, so the check constrains how these paths may be written
+- Another thing to update when adding a contract — though that is the point
+
+### Risks
+
+- **False confidence.** A passing check proves the strings match, not that the halt logic
+  works. The distinction should be stated where the check reports, or it invites exactly
+  the assumption it cannot support.
+
+## Architecture Impact
+
+- **Update:** `docs/architecture/plugin-system.md` — the contract table becomes normative,
+  and its format becomes load-bearing
+- **No new ADR.** This implements a check for a coupling ADR-018 and ADR-022 already
+  established; it makes no new architectural choice
+
+## Open Questions
+
+None blocking. The one judgement call — parse the existing table rather than add a
+manifest — is argued in Alternative 1.

--- a/docs/proposals/014-verifying-cross-plugin-contracts.md
+++ b/docs/proposals/014-verifying-cross-plugin-contracts.md
@@ -1,7 +1,7 @@
 ---
 title: "Verifying Cross-Plugin File-Path Contracts"
 number: "014"
-status: draft
+status: accepted
 author: Alex
 created: 2026-07-28
 updated: 2026-07-28

--- a/scripts/check-skill-references.sh
+++ b/scripts/check-skill-references.sh
@@ -127,4 +127,164 @@ if [[ "$WARNINGS" -gt 0 ]]; then
   exit 1
 fi
 
+# ===========================================================================
+# Cross-plugin file-path contracts (RFC-014)
+#
+# Plugins install independently and cannot reference each other's
+# ${CLAUDE_PLUGIN_ROOT} (ADR-018), so where two must cooperate the coupling is a
+# bare path at the repository root. Those paths are invisible to the reference
+# check above: nothing resolves them, and a rename breaks them silently.
+#
+# The halt switch is the case that matters. /orchestrate stops at a phase boundary
+# by testing for .agents/HALT — a path it learns from prose. Rename it and the kill
+# switch stops working with no failing test, which is exactly the scenario ADR-022
+# exists to prevent.
+#
+# The contract table in docs/architecture/plugin-system.md is the declaration of
+# record. It is parsed rather than duplicated into a manifest, because a duplicated
+# declaration drifts — the problem ADR-018 solved by deleting copies.
+#
+# NOTE: this compares literal strings. It proves the declaration matches the code;
+# it does not prove the halt logic works.
+# ===========================================================================
+
+CONTRACT_DOC="${REPO_ROOT}/docs/architecture/plugin-system.md"
+CONTRACT_FAILURES=0
+CONTRACTS_CHECKED=0
+
+echo ""
+echo "Checking cross-plugin file-path contracts..."
+
+if [[ ! -f "$CONTRACT_DOC" ]]; then
+  echo "FAIL: contract declaration not found at docs/architecture/plugin-system.md"
+  exit 1
+fi
+
+# Extract the contract table. Keyed on the backticked path in the first cell rather
+# than on column position, so a formatter reflowing the columns does not break it.
+CONTRACT_ROWS="$(awk '
+  /^## Cross-plugin coupling/ { in_section = 1; next }
+  in_section && /^## / { exit }
+  in_section && /^\|[[:space:]]*`/ {
+    line = $0
+    sub(/^\|[[:space:]]*/, "", line)
+    n = split(line, cell, "|")
+    if (n < 3) next
+    path = cell[1]; writer = cell[2]; readers = cell[3]
+    gsub(/`/, "", path)
+    gsub(/^[ \t]+|[ \t]+$/, "", path)
+    gsub(/^[ \t]+|[ \t]+$/, "", writer)
+    gsub(/^[ \t]+|[ \t]+$/, "", readers)
+    if (path == "" || path == "Path") next
+    print path "\t" writer "\t" readers
+  }
+' "$CONTRACT_DOC")"
+
+if [[ -z "$CONTRACT_ROWS" ]]; then
+  echo "FAIL: no contract rows parsed from docs/architecture/plugin-system.md."
+  echo "      The table under '## Cross-plugin coupling' is the declaration of record;"
+  echo "      a silently empty parse would let every contract go unchecked."
+  exit 1
+fi
+
+# Names of plugins mentioned in a table cell.
+plugins_in_cell() {
+  printf '%s' "$1" | grep -oE 'principled-[a-z]+' | sort -u
+}
+
+# Does a plugin reference this literal path anywhere in its tree?
+# Markdown counts: a SKILL.md instructing the model to read a path IS the read.
+plugin_references_path() {
+  grep -rqF -- "$2" "${REPO_ROOT}/plugins/$1" 2> /dev/null
+}
+
+while IFS="$(printf '\t')" read -r c_path c_writer c_readers; do
+  [[ -n "$c_path" ]] || continue
+  CONTRACTS_CHECKED=$((CONTRACTS_CHECKED + 1))
+
+  writer_plugin="$(plugins_in_cell "$c_writer" | head -1)"
+  if [[ -z "$writer_plugin" ]]; then
+    echo "  FAIL: ${c_path} — no writing plugin named in the table"
+    CONTRACT_FAILURES=$((CONTRACT_FAILURES + 1))
+    continue
+  fi
+
+  if [[ ! -d "${REPO_ROOT}/plugins/${writer_plugin}" ]]; then
+    echo "  FAIL: ${c_path} — declared writer '${writer_plugin}' is not a plugin"
+    CONTRACT_FAILURES=$((CONTRACT_FAILURES + 1))
+    continue
+  fi
+
+  if ! plugin_references_path "$writer_plugin" "$c_path"; then
+    echo "  FAIL: ${c_path} — declared writer '${writer_plugin}' never references it"
+    echo "        Either the path was renamed, or the declaration is stale."
+    CONTRACT_FAILURES=$((CONTRACT_FAILURES + 1))
+    continue
+  fi
+
+  # "any plugin" is an explicit wildcard: no reader requirement, and undeclared
+  # readers are expected rather than a finding.
+  if printf '%s' "$c_readers" | grep -qi 'any plugin'; then
+    echo "  OK: ${c_path} — writer ${writer_plugin}, readers unrestricted"
+    continue
+  fi
+
+  row_failed=0
+  # Space-separated, not newline-separated: the membership test below is a glob
+  # against " $declared_readers ", and a newline separator silently never matches —
+  # which flags every reader on a multi-reader row as undeclared.
+  declared_readers="$(plugins_in_cell "$c_readers" | tr '\n' ' ')"
+
+  for reader in $declared_readers; do
+    if [[ ! -d "${REPO_ROOT}/plugins/${reader}" ]]; then
+      echo "  FAIL: ${c_path} — declared reader '${reader}' is not a plugin"
+      CONTRACT_FAILURES=$((CONTRACT_FAILURES + 1))
+      row_failed=1
+      continue
+    fi
+    if ! plugin_references_path "$reader" "$c_path"; then
+      echo "  FAIL: ${c_path} — declared reader '${reader}' does not use this literal"
+      echo "        A reader looking for a different string is the silent break."
+      CONTRACT_FAILURES=$((CONTRACT_FAILURES + 1))
+      row_failed=1
+    fi
+  done
+
+  # Any plugin using the path that the table does not account for is undeclared
+  # coupling: real, and invisible to review until it breaks.
+  for candidate_dir in "${REPO_ROOT}"/plugins/*/; do
+    candidate="$(basename "$candidate_dir")"
+    [[ "$candidate" == "$writer_plugin" ]] && continue
+    case " $declared_readers " in
+    *" $candidate "*) continue ;;
+    esac
+    if plugin_references_path "$candidate" "$c_path"; then
+      echo "  FAIL: ${c_path} — '${candidate}' references it but is not declared"
+      echo "        Add it to the table, or remove the reference."
+      CONTRACT_FAILURES=$((CONTRACT_FAILURES + 1))
+      row_failed=1
+    fi
+  done
+
+  if [[ "$row_failed" -eq 0 ]]; then
+    echo "  OK: ${c_path} — writer ${writer_plugin}, readers ${declared_readers% }"
+  fi
+done << EOF
+$CONTRACT_ROWS
+EOF
+
+echo ""
+echo "Checked ${CONTRACTS_CHECKED} cross-plugin contract(s)."
+
+if [[ "$CONTRACT_FAILURES" -gt 0 ]]; then
+  echo "FAIL: ${CONTRACT_FAILURES} contract violation(s)."
+  echo ""
+  echo "The table under '## Cross-plugin coupling' in"
+  echo "docs/architecture/plugin-system.md is the declaration of record. Update it,"
+  echo "or fix the code to match."
+  exit 1
+fi
+
+echo ""
 echo "PASS: All ${CHECKED} references resolve and use a portable path."
+echo "PASS: All ${CONTRACTS_CHECKED} declared contracts match the code (literal strings only)."

--- a/tests/contract-verification.bats
+++ b/tests/contract-verification.bats
@@ -1,0 +1,160 @@
+#!/usr/bin/env bats
+# Tests for the cross-plugin contract verification in
+# scripts/check-skill-references.sh (RFC-014, Plan-012).
+#
+# The check exists because the halt switch is coupled by a bare path that nothing
+# resolves: /orchestrate tests for .agents/HALT, a string it learns from prose. Rename
+# it and the kill switch stops working with no failing test — the exact scenario
+# ADR-022 exists to prevent.
+#
+# So the load-bearing test here is not "the repository passes". It is "a rename FAILS".
+# A checker that cannot fail is decoration, and the repository already had one form of
+# that: the table these contracts live in was documented as unverified.
+#
+# Each test copies the repository into a temp directory and mutates the copy, so a
+# failure case can be constructed without touching the working tree.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+  WORK="${BATS_TEST_TMPDIR}/repo"
+  mkdir -p "$WORK"
+  # Copy only what the check reads: the declaration and the plugin tree.
+  mkdir -p "${WORK}/scripts" "${WORK}/docs/architecture" "${WORK}/plugins"
+  cp "${REPO_ROOT}/scripts/check-skill-references.sh" "${WORK}/scripts/"
+  cp "${REPO_ROOT}/docs/architecture/plugin-system.md" "${WORK}/docs/architecture/"
+  cp -R "${REPO_ROOT}/plugins/." "${WORK}/plugins/"
+  CHECK="${WORK}/scripts/check-skill-references.sh"
+  DOC="${WORK}/docs/architecture/plugin-system.md"
+}
+
+# Run the check and return only the contract section, so assertions are not confused
+# by the reference-resolution output above it.
+run_contracts() {
+  run bash "$CHECK"
+}
+
+# --- The repository as it stands ---
+
+@test "every declared contract passes against the real repository" {
+  run_contracts
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "declared contracts match the code"
+}
+
+@test "all four contracts are discovered, not silently skipped" {
+  run_contracts
+  echo "$output" | grep -q "Checked 4 cross-plugin contract(s)"
+}
+
+@test "the halt switch contract is among them" {
+  run_contracts
+  echo "$output" | grep -q "OK: .agents/HALT — writer principled-agent"
+}
+
+# --- The failure this exists to catch ---
+
+@test "renaming the halt switch in the writer fails the check" {
+  # Simulate principled-agent renaming HALT without telling anyone.
+  grep -rlF '.agents/HALT' "${WORK}/plugins/principled-agent" \
+    | while IFS= read -r f; do
+      sed 's|\.agents/HALT|.agents/STOP|g' "$f" > "${f}.tmp" && mv "${f}.tmp" "$f"
+    done
+  run_contracts
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q "declared writer 'principled-agent' never references it"
+}
+
+@test "a reader drifting to a different literal fails the check" {
+  # principled-implementation looks for a path principled-agent never writes.
+  grep -rlF '.agents/HALT' "${WORK}/plugins/principled-implementation" \
+    | while IFS= read -r f; do
+      sed 's|\.agents/HALT|.agents/halt|g' "$f" > "${f}.tmp" && mv "${f}.tmp" "$f"
+    done
+  run_contracts
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q "declared reader 'principled-implementation' does not use this literal"
+}
+
+@test "an undeclared cross-plugin reader fails the check" {
+  # principled-release starts reading the manifest without a table entry.
+  printf 'Reads .agents/HALT for no good reason.\n' >> "${WORK}/plugins/principled-release/README.md"
+  run_contracts
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q "'principled-release' references it but is not declared"
+}
+
+@test "a contract naming a nonexistent plugin fails" {
+  sed 's|^| `.agents/HALT` .*| `.agents/HALT`  | principled-nope |g' "$DOC" > /dev/null 2>&1 || true
+  python3 - "$DOC" << 'PY'
+import sys, pathlib
+p = pathlib.Path(sys.argv[1]); t = p.read_text()
+t = t.replace("| `.agents/HALT`            | principled-agent",
+              "| `.agents/HALT`            | principled-nope ")
+p.write_text(t)
+PY
+  run_contracts
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q "is not a plugin"
+}
+
+# --- Parser robustness ---
+
+@test "a missing declaration table fails loudly rather than passing vacuously" {
+  # The contract section is currently the last in the file, so a lookahead for a
+  # following heading would match nothing and silently leave the table in place.
+  python3 - "$DOC" << 'PY'
+import sys, pathlib, re
+p = pathlib.Path(sys.argv[1]); t = p.read_text()
+new, n = re.subn(r'^## Cross-plugin coupling.*?(?=^## |\Z)', '', t, flags=re.S | re.M)
+assert n == 1 and '## Cross-plugin coupling' not in new, "section was not removed"
+p.write_text(new)
+PY
+  run_contracts
+  [ "$status" -eq 1 ]
+  # A silently empty parse would let every contract go unchecked — worse than no check.
+  echo "$output" | grep -q "no contract rows parsed"
+}
+
+@test "reflowing the table columns does not break the parser" {
+  # The parser keys on the backticked path, not on column width. Prettier reflows
+  # these columns whenever a cell changes length, so this must not matter.
+  python3 - "$DOC" << 'PY'
+import sys, pathlib, re
+p = pathlib.Path(sys.argv[1]); t = p.read_text()
+out = []
+for line in t.splitlines():
+    if line.startswith('| `') or re.match(r'^\| -+ \|', line):
+        line = re.sub(r'[ \t]+\|', ' |', line)
+        line = re.sub(r'\|[ \t]+', '| ', line)
+    out.append(line)
+p.write_text("\n".join(out) + "\n")
+PY
+  run_contracts
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "Checked 4 cross-plugin contract(s)"
+}
+
+@test "a multi-reader row accepts every declared reader" {
+  # Regression: declared readers were newline-separated while the membership test was
+  # a glob against " $readers ", so a newline never matched and every reader on a
+  # multi-reader row was reported undeclared. The manifest row has three.
+  run_contracts
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "OK: .impl/manifest.json"
+  ! echo "$output" | grep -q "principled-github' references it but is not declared"
+}
+
+@test "an 'any plugin' wildcard imposes no reader requirement" {
+  # .principled/tasks.jsonl is readable by anything; adding a new reader must not fail.
+  printf 'Mentions .principled/tasks.jsonl in passing.\n' >> "${WORK}/plugins/principled-quality/README.md"
+  run_contracts
+  [ "$status" -eq 0 ]
+}
+
+# --- Reporting honesty ---
+
+@test "the check states that it compares strings rather than behaviour" {
+  run_contracts
+  # Without this, a green check reads as "the halt switch works", which it cannot prove.
+  echo "$output" | grep -q "literal strings only"
+}


### PR DESCRIPTION
Closes #36. Implements [RFC-014](docs/proposals/014-verifying-cross-plugin-contracts.md) via [Plan-012](docs/plans/012-verifying-cross-plugin-contracts.md).

> **Draft and `agent-authored` by protocol.** Promotion to ready-for-review and merge are human acts (ADR-022), and the label is what the in-flight PR budget counts.

## The gap

Plugins install independently and cannot reference each other's `${CLAUDE_PLUGIN_ROOT}` (ADR-018), so where two cooperate the coupling is a bare path at the repository root. Nothing in CI could see those.

The halt switch is why it matters: `/orchestrate` stops at a phase boundary by testing for `.agents/HALT`, a string it learns from prose. **Rename it and the kill switch stops working with no failing test** — the exact scenario ADR-022 exists to prevent.

## The change

`check-skill-references.sh` now parses the contract table in `plugin-system.md` as a declaration of record and verifies per row: the named writer references the literal path, every named reader uses the same string, and no undeclared plugin reads it.

Parsing the existing table rather than adding a JSON manifest avoids the duplicated declaration ADR-018 removed elsewhere. The cost is that the table's format becomes load-bearing — so the parser keys on the backticked path cell, never on column position, and there's a test proving a prettier reflow doesn't break it. (Prettier reflowed this very table mid-run, which exercised it for real.)

## It found something immediately

`.impl/manifest.json` was declared as read only by principled-agent. It's also read by **principled-github** — `pr-describe/scripts/task-manifest.sh` opens the file directly — and referenced by principled-tasks. Real coupling, undocumented, invisible to every other check. The table now declares all three readers.

## And it caught a bug in itself

The first implementation reported every reader on a multi-reader row as undeclared: `declared_readers` was newline-separated while the membership test globbed against `" $declared_readers "`, so a newline never matched. Single-reader rows passed and masked it; the three-reader manifest row exposed it. Fixed, and pinned by a test.

## Scope, stated plainly

**This compares literal strings.** A green result means the declaration matches the code — not that the halt logic works. A path assembled at runtime (`"${dir}/HALT"`) is invisible to it. The output says so, because a check inviting more confidence than it earns is worse than no check.

## Verification

`just ci` green — **170 tests, up from 158**. `tests/contract-verification.bats` (12) copies the repo to a temp dir and mutates the copy, so failures are constructed rather than asserted: renaming the halt path fails, a reader drifting to `.agents/halt` fails, an undeclared reader fails, a missing table fails loudly rather than passing vacuously.

---

## Protocol run notes

This is the **first end-to-end run of the Agent Contributor Protocol** (RFC-012), via `/agent-dispatch 36 --local`.

What worked: the governance gate queried the live API and reported `0/5` and `0/5` before anything else; the human approval gate held and did not proceed on silence.

What didn't, filed as issues rather than worked around:
- **#37** — routing is nominal. `specializations` is `[]` for every agent and nothing populates it, so routing always falls back to `impl-worker`.
- **#38** — `/ingest-issue`'s "Plan only" classification is unreachable. `check-plan-proposal-link.sh` blocks any plan without an accepted proposal, so every dispatched issue must produce an RFC. #36 needed RFC-014 to exist purely so a plan could reference it.

Retrospective in `.agents/retrospectives/2026-07-28-issue-36.md`; four durable learnings promoted to `impl-worker` memory (now 1231 bytes, well under budget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKzFURKGfB1Ec3ayH2hjE2