### PR TITLE
fix: declare contract writers as files, catching partial renames (#40)

### DIFF
--- a/docs/architecture/plugin-system.md
+++ b/docs/architecture/plugin-system.md
@@ -192,21 +192,25 @@ Constraint 3 means two plugins that must cooperate cannot call each other. Where
 cooperation is genuinely required, the coupling is a **committed file at a fixed
 repository-root path**, which both read independently:
 
-| Path                      | Written by                | Read by                                                                         |
-| ------------------------- | ------------------------- | ------------------------------------------------------------------------------- |
-| `.agents/`                | principled-agent          | any plugin; injected at spawn (ADR-020)                                         |
-| `.agents/HALT`            | principled-agent          | principled-implementation at phase boundaries                                   |
-| `.impl/manifest.json`     | principled-implementation | principled-agent, principled-github, principled-tasks — all read-only (ADR-021) |
-| `.principled/tasks.jsonl` | principled-tasks          | any plugin, read-only (ADR-017)                                                 |
+| Path                      | Written by                                       | Read by                                                                         |
+| ------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------- |
+| `.agents/`                | `principled-agent/lib/agent-memory.sh`           | any plugin; injected at spawn (ADR-020)                                         |
+| `.agents/HALT`            | `principled-agent/lib/agent-governance.sh`       | principled-implementation at phase boundaries                                   |
+| `.impl/manifest.json`     | `principled-implementation/lib/task-manifest.sh` | principled-agent, principled-github, principled-tasks — all read-only (ADR-021) |
+| `.principled/tasks.jsonl` | `principled-tasks/lib/task-db.sh`                | any plugin, read-only (ADR-017)                                                 |
 
 This is the only mechanism available, and for the halt switch it is also the right one:
 the switch must be operable by a human with no running session (ADR-022).
 
 **This table is a declaration of record, not documentation.**
 `scripts/check-skill-references.sh` parses it and verifies, for every row, that the
-named writer references the literal path, that every named reader uses the same string,
-and that no undeclared plugin reads it. A rename that would silently disable the halt
-switch now fails CI (RFC-014).
+**declared writing file** contains the literal path, that every named reader plugin uses
+the same string, and that no undeclared plugin reads it (RFC-014).
+
+The writer is a **file**, not a plugin, and that granularity is the point. A
+plugin-granular check passes when the implementing script is renamed but stale mentions
+survive elsewhere in the same plugin — which is the likelier refactor and the one that
+silently breaks the halt switch (#40).
 
 Two consequences follow. The table's **format is load-bearing** — rows are keyed on the
 backticked path in the first cell, so that cell must stay backticked. And adding a

--- a/scripts/check-skill-references.sh
+++ b/scripts/check-skill-references.sh
@@ -144,6 +144,11 @@ fi
 # record. It is parsed rather than duplicated into a manifest, because a duplicated
 # declaration drifts — the problem ADR-018 solved by deleting copies.
 #
+# The writer is declared as a FILE, not a plugin: a plugin-granular check passes when
+# the implementing script is renamed but stale mentions survive elsewhere in the same
+# plugin, which is the likelier refactor and the one that silently breaks the halt
+# switch (#40).
+#
 # NOTE: this compares literal strings. It proves the declaration matches the code;
 # it does not prove the halt logic works.
 # ===========================================================================
@@ -202,9 +207,16 @@ while IFS="$(printf '\t')" read -r c_path c_writer c_readers; do
   [[ -n "$c_path" ]] || continue
   CONTRACTS_CHECKED=$((CONTRACTS_CHECKED + 1))
 
-  writer_plugin="$(plugins_in_cell "$c_writer" | head -1)"
-  if [[ -z "$writer_plugin" ]]; then
-    echo "  FAIL: ${c_path} — no writing plugin named in the table"
+  # The writer is declared as a plugin-relative FILE, not a plugin. A plugin-granular
+  # check passes when the implementing script is renamed but stale mentions survive
+  # elsewhere in the same plugin — the likelier refactor, and the one that silently
+  # breaks the halt switch (#40).
+  writer_file="$(printf '%s' "$c_writer" | tr -d '`' | tr -d ' ')"
+  writer_plugin="${writer_file%%/*}"
+
+  if [[ -z "$writer_file" || "$writer_file" != */* ]]; then
+    echo "  FAIL: ${c_path} — writer must be a plugin-relative file path"
+    echo "        Got '${c_writer}'. Declaring only a plugin cannot catch a partial rename."
     CONTRACT_FAILURES=$((CONTRACT_FAILURES + 1))
     continue
   fi
@@ -215,9 +227,17 @@ while IFS="$(printf '\t')" read -r c_path c_writer c_readers; do
     continue
   fi
 
-  if ! plugin_references_path "$writer_plugin" "$c_path"; then
-    echo "  FAIL: ${c_path} — declared writer '${writer_plugin}' never references it"
-    echo "        Either the path was renamed, or the declaration is stale."
+  if [[ ! -f "${REPO_ROOT}/plugins/${writer_file}" ]]; then
+    echo "  FAIL: ${c_path} — declared writing file does not exist"
+    echo "        Expected plugins/${writer_file}"
+    CONTRACT_FAILURES=$((CONTRACT_FAILURES + 1))
+    continue
+  fi
+
+  if ! grep -qF -- "$c_path" "${REPO_ROOT}/plugins/${writer_file}" 2> /dev/null; then
+    echo "  FAIL: ${c_path} — declared writer plugins/${writer_file} does not contain it"
+    echo "        The implementing file was renamed away from the declared path, or the"
+    echo "        declaration is stale. Stale mentions elsewhere in the plugin do not count."
     CONTRACT_FAILURES=$((CONTRACT_FAILURES + 1))
     continue
   fi
@@ -225,7 +245,7 @@ while IFS="$(printf '\t')" read -r c_path c_writer c_readers; do
   # "any plugin" is an explicit wildcard: no reader requirement, and undeclared
   # readers are expected rather than a finding.
   if printf '%s' "$c_readers" | grep -qi 'any plugin'; then
-    echo "  OK: ${c_path} — writer ${writer_plugin}, readers unrestricted"
+    echo "  OK: ${c_path} — writer ${writer_file}, readers unrestricted"
     continue
   fi
 
@@ -267,7 +287,7 @@ while IFS="$(printf '\t')" read -r c_path c_writer c_readers; do
   done
 
   if [[ "$row_failed" -eq 0 ]]; then
-    echo "  OK: ${c_path} — writer ${writer_plugin}, readers ${declared_readers% }"
+    echo "  OK: ${c_path} — writer ${writer_file}, readers ${declared_readers% }"
   fi
 done << EOF
 $CONTRACT_ROWS

--- a/tests/contract-verification.bats
+++ b/tests/contract-verification.bats
@@ -53,15 +53,61 @@ run_contracts() {
 
 # --- The failure this exists to catch ---
 
-@test "renaming the halt switch in the writer fails the check" {
-  # Simulate principled-agent renaming HALT without telling anyone.
+@test "renaming the halt switch everywhere in the writer fails the check" {
+  # A complete rename: principled-agent drops the path entirely.
   grep -rlF '.agents/HALT' "${WORK}/plugins/principled-agent" \
     | while IFS= read -r f; do
       sed 's|\.agents/HALT|.agents/STOP|g' "$f" > "${f}.tmp" && mv "${f}.tmp" "$f"
     done
   run_contracts
   [ "$status" -eq 1 ]
-  echo "$output" | grep -q "declared writer 'principled-agent' never references it"
+  echo "$output" | grep -q "does not contain it"
+}
+
+@test "renaming the halt switch in ONLY the implementing file fails the check" {
+  # The regression from #40, and the more likely refactor: someone edits the
+  # implementation and does not grep for stale mentions. principled-agent references
+  # .agents/HALT in three files, so a plugin-granular check passed here while the
+  # kill switch was genuinely broken — the exact failure RFC-014 targeted.
+  #
+  # The original test suite missed this because it renamed across every file in the
+  # plugin, sharing the check's blind spot.
+  f="${WORK}/plugins/principled-agent/lib/agent-governance.sh"
+  sed 's|\.agents/HALT|.agents/STOPPED|g' "$f" > "${f}.tmp" && mv "${f}.tmp" "$f"
+
+  # Stale references survive elsewhere in the plugin — that is what made it invisible.
+  [ "$(grep -rlF '.agents/HALT' "${WORK}/plugins/principled-agent" | wc -l | tr -d ' ')" -gt 0 ]
+
+  run_contracts
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q "agent-governance.sh does not contain it"
+}
+
+@test "a writer declared as a bare plugin name is rejected" {
+  # Plugin granularity cannot catch a partial rename, so it is not an accepted
+  # declaration form.
+  python3 - "$DOC" << 'PY'
+import sys, pathlib
+p = pathlib.Path(sys.argv[1]); t = p.read_text()
+t = t.replace("`principled-agent/lib/agent-governance.sh`", "principled-agent")
+p.write_text(t)
+PY
+  run_contracts
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q "writer must be a plugin-relative file path"
+}
+
+@test "a declared writing file that does not exist fails" {
+  python3 - "$DOC" << 'PY'
+import sys, pathlib
+p = pathlib.Path(sys.argv[1]); t = p.read_text()
+t = t.replace("`principled-agent/lib/agent-governance.sh`",
+              "`principled-agent/lib/does-not-exist.sh`")
+p.write_text(t)
+PY
+  run_contracts
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q "declared writing file does not exist"
 }
 
 @test "a reader drifting to a different literal fails the check" {
@@ -84,12 +130,11 @@ run_contracts() {
 }
 
 @test "a contract naming a nonexistent plugin fails" {
-  sed 's|^| `.agents/HALT` .*| `.agents/HALT`  | principled-nope |g' "$DOC" > /dev/null 2>&1 || true
   python3 - "$DOC" << 'PY'
 import sys, pathlib
 p = pathlib.Path(sys.argv[1]); t = p.read_text()
-t = t.replace("| `.agents/HALT`            | principled-agent",
-              "| `.agents/HALT`            | principled-nope ")
+t = t.replace("`principled-agent/lib/agent-governance.sh`",
+              "`principled-nope/lib/agent-governance.sh`")
 p.write_text(t)
 PY
   run_contracts


### PR DESCRIPTION
Closes #40.

## The defect

The check shipped in #39 asked *"does the writing **plugin** reference this literal anywhere?"* — plugin-granular. `principled-agent` mentions `.agents/HALT` in three files, so renaming it in the implementing script alone left two stale references and CI stayed green:

```
agent-governance.sh now writes: .agents/STOPPED
/orchestrate still looks for:   .agents/HALT
--> the kill switch is BROKEN
    check exit=0   FAIL lines: 0
```

**That is the exact failure RFC-014 was written to prevent, shipped inside the change meant to prevent it.**

## Why the tests didn't catch it

`tests/contract-verification.bats` renamed the path across *every* file in the writer plugin — a complete rename. **The test and the check shared a blind spot**, so twelve passing tests bought less confidence than they appeared to. I found this by breaking the merged result on `main`, not from the suite.

## The fix

The declaration now names the writing **file**:

| Path | Written by |
|---|---|
| `.agents/HALT` | `principled-agent/lib/agent-governance.sh` |

and the check verifies *that file* contains the literal. Stale mentions elsewhere in the plugin no longer count. A bare plugin name is rejected outright, since it cannot catch a partial rename.

**Readers stay plugin-granular** — a reader that drops the path entirely is already caught, and pinning readers to files would make ordinary refactoring noisy for no safety gain.

## Verification

Three tests added for what nothing covered:

- a rename in **only** the implementing file (the #40 regression)
- a writer declared as a bare plugin name
- a declared writing file that doesn't exist

I broke it on `main` first and confirmed `exit=0`, then confirmed the fix reports:

```
FAIL: .agents/HALT — declared writer plugins/principled-agent/lib/agent-governance.sh
      does not contain it
      Stale mentions elsewhere in the plugin do not count.
```

`just ci` green — **173 tests, up from 170**.

`plugin-system.md` overstated the guarantee and is corrected here too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKzFURKGfB1Ec3ayH2hjE2