### PR TITLE
chore: record the shipped defect in the retrospective and memory

### DIFF
--- a/.agents/memory/agents/impl-worker.md
+++ b/.agents/memory/agents/impl-worker.md
@@ -2,8 +2,8 @@
 agent_id: "impl-worker"
 role: worker
 last_updated: 2026-07-28
-session_count: 1
-total_tasks: 4
+session_count: 2
+total_tasks: 5
 success_rate: 1.00
 specializations: []
 ---
@@ -18,6 +18,10 @@ specializations: []
 - Prettier reflows markdown table column widths whenever a cell's length changes. Parse
   tables by cell content, never by column position — and never trust a string-replace
   against a table row to have applied, because a no-op replace fails silently.
+- A test that mutates state the same way the code inspects it proves agreement, not
+  correctness. `check-skill-references.sh` compared a path plugin-wide while its test
+  renamed the path plugin-wide, so twelve green tests hid a live defect. When writing a
+  test for a checker, break the thing in a way the checker was _not_ written to see.
 
 ## Pitfalls
 

--- a/.agents/retrospectives/2026-07-28-issue-36.md
+++ b/.agents/retrospectives/2026-07-28-issue-36.md
@@ -8,6 +8,8 @@ mode: local
 tasks_total: 4
 tasks_merged: 4
 tasks_failed: 0
+defects_shipped: 1
+followup_prs: 1
 ---
 
 # Retrospective — Issue #36, the first protocol run
@@ -81,3 +83,43 @@ Candidates for memory. Each is a fact about this codebase rather than about this
 - "task-2b failed twice" style facts — there were none; the run had no failures.
 - The routing and "Plan only" findings are defects in this repository, not knowledge an
   agent should carry. They belong in issues, filed below.
+
+## Addendum: the run shipped a defect
+
+Written after #41 merged.
+
+PR #39 was reviewed, approved and merged. Verifying the merged result on `main` — rather
+than trusting the suite — showed the new check did **not** catch the failure it was built
+for. It asked "does the writing _plugin_ reference this literal anywhere?", and
+`principled-agent` mentions `.agents/HALT` in three files. Renaming it in the implementing
+script alone left two stale references and CI stayed green while the kill switch was
+broken.
+
+Twelve passing tests did not catch it, because `tests/contract-verification.bats` renamed
+the path across every file in the plugin — exactly matching what the check could see.
+**The test and the check shared a blind spot**, so the suite measured agreement between
+two things written the same way, not correctness.
+
+Fixed in #41: the declaration now names the writing _file_, a bare plugin name is
+rejected, and three tests cover what nothing covered. Verified by breaking it on `main`
+first, confirming `exit=0`, then confirming the fix reports the failure.
+
+### What this says about the metrics
+
+`success_rate` now reads **1.00 over 5 tasks**, and that number is misleading. Every task
+merged, so by the manifest's definition every task succeeded — but the run shipped a
+defect serious enough to need a follow-up PR, and nothing in the metric registers that.
+
+This matters for RFC-013, which plans to synthesize agent improvements from exactly these
+numbers. A metric that scores "merged" as "correct" will rank a run that shipped a latent
+defect identically to one that did not, and an improvement loop optimizing against it
+would learn nothing from this run — arguably the most instructive one so far.
+
+Whatever RFC-013 consumes, task-merge rate alone is not it. `defects_shipped` and
+`followup_prs` are in this retrospective's frontmatter as a starting point.
+
+### Promoted from the addendum
+
+- A test that mutates state the same way the code inspects it proves agreement, not
+  correctness. When testing a checker, break the thing in a way the checker was _not_
+  written to see.


### PR DESCRIPTION
Follow-up to #39/#41, written **after** the fix merged rather than before — promoting a lesson from unmerged work is how memory fills with things that later turn out wrong.

## Memory

`impl-worker` gains the lesson that actually mattered:

> A test that mutates state the same way the code inspects it proves agreement, not correctness. When testing a checker, break the thing in a way the checker was *not* written to see.

`tests/contract-verification.bats` renamed a path plugin-wide while the check compared it plugin-wide. Twelve green tests hid a live defect.

Memory is now 1574 bytes — comfortably under the 8 KB budget.

## Retrospective addendum

Records that the run shipped a defect, and flags a problem with the metric now describing it.

**`success_rate` reads 1.00 over 5 tasks.** Every task merged, so by the manifest's definition every task succeeded — but the run shipped a defect serious enough to need a follow-up PR, and nothing in the metric registers that.

This matters beyond bookkeeping. **RFC-013 plans to synthesize agent improvements from exactly these numbers.** A metric that scores "merged" as "correct" ranks a run that shipped a latent defect identically to one that didn't, and an improvement loop optimizing against it would learn nothing from arguably the most instructive run so far.

`defects_shipped: 1` and `followup_prs: 1` are added to the frontmatter as a starting point — not a proposal, just the observation that task-merge rate alone isn't the signal RFC-013 needs.

`just ci` green — 173 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKzFURKGfB1Ec3ayH2hjE2