### PR TITLE
fix: route dispatch by role, and drop the unreachable "Plan only" path

### DIFF
--- a/docs/architecture/agent-collaboration.md
+++ b/docs/architecture/agent-collaboration.md
@@ -34,6 +34,18 @@ letting agents open PRs against a repository.
 owns every irreversible decision. Steps 3, 5, 8 and 11 are cheap to redo; steps 4, 6, 10
 and 12 are not.
 
+### Not every issue takes the long path
+
+Steps 3–6 apply to **design work**. `/ingest-issue` classifies first, and a fix or chore
+worth roughly one PR produces **no pipeline documents at all** — implement, self-review,
+draft PR, human merges. That is how most fixes in this repository have actually shipped.
+
+There is deliberately no "plan without a proposal" option:
+`check-plan-proposal-link.sh` blocks it, and correctly — a plan is a DDD decomposition of
+an accepted design, so a plan with no design is a decomposition of nothing. The trap is
+inventing an RFC purely to unlock a plan for work nothing will orchestrate, which puts a
+fake design on the permanent record to satisfy a guard (#38).
+
 The protocol is a workflow pattern, not a platform. It runs identically with
 `/agent-dispatch --local` in a terminal and through CI.
 

--- a/plugins/principled-agent/README.md
+++ b/plugins/principled-agent/README.md
@@ -116,6 +116,9 @@ cannot be deleted compounds on every spawn.
 
 Metric fields are script-owned. Use `--update-metrics`, don't hand-edit them.
 
+`specializations` is reserved and unused — nothing populates it, so dispatch routes by
+`role` from the registry instead (#37).
+
 ## Forks
 
 `.agents/` is committed, so a fork inherits everything. Knowledge should transfer;

--- a/plugins/principled-agent/lib/agent-memory.sh
+++ b/plugins/principled-agent/lib/agent-memory.sh
@@ -206,6 +206,31 @@ agent_memory_path() {
 }
 
 # Ids of every agent the registry marks memory:true.
+# Role of an agent, from the registry. This is the routing key: it is populated for
+# every agent and stable, unlike `specializations` which nothing writes (#37).
+agent_role() {
+  [[ -f "$REGISTRY" ]] || return 0
+  if $HAS_JQ; then
+    jq -r --arg id "$1" '.agents[] | select(.id == $id) | .role' "$REGISTRY" 2> /dev/null
+  else
+    awk -v want="$1" '
+      /"id"[[:space:]]*:/ {
+        line = $0
+        sub(/.*"id"[[:space:]]*:[[:space:]]*"/, "", line)
+        sub(/".*/, "", line)
+        current = line
+      }
+      current == want && /"role"[[:space:]]*:/ {
+        line = $0
+        sub(/.*"role"[[:space:]]*:[[:space:]]*"/, "", line)
+        sub(/".*/, "", line)
+        print line
+        exit
+      }
+    ' "$REGISTRY"
+  fi
+}
+
 registry_agent_ids() {
   [[ -f "$REGISTRY" ]] || return 0
   if $HAS_JQ; then
@@ -415,19 +440,20 @@ if [[ "$OPERATION" == "list" ]]; then
     done
     printf '\n  ]\n}\n'
   else
-    printf '%-18s %8s %9s %7s %9s  %s\n' "AGENT" "BYTES" "SESSIONS" "TASKS" "SUCCESS" "UPDATED"
+    printf '%-18s %-10s %8s %9s %7s %9s  %s\n' "AGENT" "ROLE" "BYTES" "SESSIONS" "TASKS" "SUCCESS" "UPDATED"
     for id in $(registry_agent_ids); do
       mem_file="$(agent_memory_path "$id")"
       if [[ -f "$mem_file" ]]; then
-        printf '%-18s %8s %9s %7s %9s  %s\n' \
+        printf '%-18s %-10s %8s %9s %7s %9s  %s\n' \
           "$id" \
+          "$(agent_role "$id")" \
           "$(file_size_bytes "$mem_file")" \
           "$(fm_get "$mem_file" session_count)" \
           "$(fm_get "$mem_file" total_tasks)" \
           "$(fm_get "$mem_file" success_rate)" \
           "$(fm_get "$mem_file" last_updated)"
       else
-        printf '%-18s %8s %9s %7s %9s  %s\n' "$id" "-" "-" "-" "-" "(no memory file)"
+        printf '%-18s %-10s %8s %9s %7s %9s  %s\n' "$id" "$(agent_role "$id")" "-" "-" "-" "-" "(no memory file)"
       fi
     done
   fi

--- a/plugins/principled-agent/skills/agent-dispatch/SKILL.md
+++ b/plugins/principled-agent/skills/agent-dispatch/SKILL.md
@@ -74,20 +74,36 @@ a refusal. Raising a cap is a human decision made deliberately, not a retry stra
    Confirm it carries `agent-ready`. If not, say so and stop — the label is how a human
    signals that an issue is understood well enough to hand over.
 
-4. **Route to an agent.** Unless `--agent` is given, pick from the registry by matching
-   the issue's labels and content against each agent's `specializations`:
+4. **Route to an agent by role.** Unless `--agent` is given, match the kind of work the
+   issue describes against each agent's `role`:
 
    ```bash
    bash "${CLAUDE_PLUGIN_ROOT}/lib/agent-memory.sh" --list
    ```
 
+   | Role       | Agent            | Takes                              |
+   | ---------- | ---------------- | ---------------------------------- |
+   | `worker`   | `impl-worker`    | Implementation — code, tests, docs |
+   | `triage`   | `issue-ingester` | Classifying and ingesting issues   |
+   | `reviewer` | `pr-reviewer`    | Reviewing an existing change       |
+
    Only agents with `memory: true` are dispatch targets; the deterministic auditors run
-   as hooks and are not assignable. If nothing matches well, default to `impl-worker` and
-   say that the routing was a fallback rather than a match.
+   as hooks and are not assignable. Most issues are implementation work and route to
+   `impl-worker` — say so plainly rather than dressing a default as a match.
+
+   **Do not route by `specializations`.** The field exists in the frontmatter but nothing
+   populates it, so every agent's is `[]` and matching against it silently falls through
+   to a default every time (#37). It is reserved for RFC-013's `/improve` to write once
+   there is evidence to write from. `role` is populated for every agent and stable, which
+   is what makes it usable as a routing key.
 
 5. **Execute.**
 
-   **With `--local`** — run the protocol in this session, no CI, no credentials:
+   **With `--local`** — run the protocol in this session, no CI, no credentials.
+
+   `/ingest-issue` classifies first, and the path depends on what it returns.
+
+   **RFC + Plan** — design work that something will orchestrate:
 
    | Step | Action                                                | Gate               |
    | ---- | ----------------------------------------------------- | ------------------ |
@@ -97,6 +113,19 @@ a refusal. Raising a cap is a human decision made deliberately, not a retry stra
    | 4    | `/review-checklist` self-review                       | —                  |
    | 5    | `/pr-describe` → **draft** PR, `agent-authored` label | **Human reviews**  |
    | 6    | Human merges                                          | **Human merges**   |
+
+   **No documents** — a fix or chore worth roughly one PR:
+
+   | Step | Action                                                | Gate              |
+   | ---- | ----------------------------------------------------- | ----------------- |
+   | 1    | Implement directly, referencing the issue             | —                 |
+   | 2    | `/review-checklist` self-review                       | —                 |
+   | 3    | `/pr-describe` → **draft** PR, `agent-authored` label | **Human reviews** |
+   | 4    | Human merges                                          | **Human merges**  |
+
+   Do not invent an RFC to unlock a plan for work nothing will orchestrate. That puts a
+   fake design on the permanent record purely to satisfy a guard, and the guard is right
+   (#38).
 
    The approval gates are the point. Stop and ask at each one; do not infer approval from
    silence or from the fact that nobody objected last time.
@@ -123,9 +152,10 @@ a refusal. Raising a cap is a human decision made deliberately, not a retry stra
 
 ## Reporting
 
-State the gate result with its numbers, which agent was chosen and whether that was a
-match or a fallback, the execution path taken, and the next human gate. If refused, lead
-with the refusal and its reason — never bury it under what you would have done.
+State the gate result with its numbers, which agent was chosen and on what role, the
+classification `/ingest-issue` returned and therefore which path was taken, and the next
+human gate. If refused, lead with the refusal and its reason — never bury it under what
+you would have done.
 
 ## Scripts
 

--- a/plugins/principled-agent/skills/agent-strategy/SKILL.md
+++ b/plugins/principled-agent/skills/agent-strategy/SKILL.md
@@ -68,6 +68,11 @@ design — a wrong learned pattern that cannot be deleted compounds on every spa
 Metric fields (`session_count`, `total_tasks`, `success_rate`, `last_updated`) are
 script-owned. Use `agent-memory.sh --update-metrics`; do not hand-edit them.
 
+`specializations` is **reserved and currently unused**. Nothing populates it, so every
+agent's is `[]`. Dispatch routes by `role` from the registry instead — a field that is
+populated for every agent and stable (#37). RFC-013's `/improve` is the intended writer,
+once there is evidence to write from.
+
 ## The context budget
 
 Every byte of memory is injected at spawn and competes with the task description for

--- a/plugins/principled-github/skills/ingest-issue/SKILL.md
+++ b/plugins/principled-github/skills/ingest-issue/SKILL.md
@@ -87,9 +87,18 @@ Ingest a GitHub issue into the principled documentation pipeline. Automatically 
    - **Mentions of architecture, API changes, or cross-cutting concerns** — suggest an RFC is needed
 
    Classification outcomes:
-   - **RFC + Plan**: The issue describes something that needs design discussion and then implementation. Most features and significant changes fall here.
-   - **Plan only**: The issue describes well-scoped work where the approach is clear and doesn't need design review. Bug fixes with known root cause, small improvements with obvious implementation.
+   - **RFC + Plan**: The issue needs design discussion and then implementation. Most features and significant changes fall here. A plan exists to be executed by `/orchestrate`, `/decompose`, or `/spawn` — if nothing will orchestrate it, it does not need a plan.
+   - **No documents**: The issue is a fix or a chore where the approach is clear and the change is roughly one PR. Implement it directly and reference the issue from the commit. This is how most fixes in this repository have actually shipped.
    - Report the classification to the user and proceed.
+
+   **There is no "Plan only" outcome, and creating a plan without a proposal will be
+   blocked** by `check-plan-proposal-link.sh` (exit 2). That guard is correct: a plan is
+   a DDD decomposition of an accepted design, so a plan with no design behind it is a
+   decomposition of nothing.
+
+   The mistake to avoid is inventing an RFC purely to unlock a plan for work that will
+   never be orchestrated. If the change is one PR's worth, take **No documents** — the
+   pipeline is for work that needs it, not a toll on every issue.
 
 6. **Determine target directory.** Based on arguments:
    - If `--root`: target is `docs/` at the repo root
@@ -140,11 +149,10 @@ Ingest a GitHub issue into the principled documentation pipeline. Automatically 
     gh issue edit <issue-number> --add-label "type:rfc,proposal:draft"
     ```
 
-    **If Plan only was created:**
+    **If no documents were created:**
 
-    ```bash
-    gh issue edit <issue-number> --add-label "type:plan,plan:active"
-    ```
+    No principled lifecycle labels apply. The issue is tracked by its own labels and
+    closed by the implementing PR.
 
 11. **Report results.** Summarize what was created:
     - Document paths and types

--- a/plugins/principled-github/skills/ingest-issue/reference/classification-guide.md
+++ b/plugins/principled-github/skills/ingest-issue/reference/classification-guide.md
@@ -23,16 +23,27 @@ When ingesting a GitHub issue, determine what principled documents to create. Th
 
 1. **Start by checking labels.** Labels are the strongest signal because humans applied them intentionally.
    - `feature`, `enhancement`, `rfc`, `proposal`, `design` → RFC + Plan
-   - `bug`, `fix`, `patch`, `hotfix`, `chore`, `task` → Plan only
+   - `bug`, `fix`, `patch`, `hotfix`, `chore`, `task` → No documents; implement directly
    - No labels or ambiguous labels → continue to body analysis
 
 2. **Analyze body content.** Look for signals of design scope:
    - Mentions of architecture, API design, data model changes, new abstractions → RFC + Plan
-   - Mentions of specific files, error messages, stack traces, concrete steps → Plan only
+   - Mentions of specific files, error messages, stack traces, concrete steps → No documents
 
-3. **Consider body length.** Longer issues with discussion of tradeoffs and alternatives suggest RFC-level scope. Short, action-oriented issues suggest plan-only.
+3. **Consider body length.** Longer issues with discussion of tradeoffs and alternatives suggest RFC-level scope. Short, action-oriented issues suggest no documents at all.
 
-4. **Default to RFC + Plan.** When in doubt, create both. An RFC that turns out to be unnecessary is cheap; a plan without proper design review can be expensive.
+4. **Ask what will consume the plan.** Plans exist to be executed by `/orchestrate`,
+   `/decompose`, or `/spawn`. If nothing will orchestrate this work, a plan is ceremony —
+   take **No documents** instead.
+
+5. **Default to RFC + Plan for design work; default to No documents for fixes.** An RFC
+   that turns out unnecessary is cheap. Inventing an RFC purely to unlock a plan is not:
+   it puts a fake design on the permanent record to satisfy a guard.
+
+**There is no "Plan only" outcome.** `check-plan-proposal-link.sh` blocks any plan whose
+`originating_proposal` is missing (exit 2), and that guard is correct — a plan is a DDD
+decomposition of an accepted design, so a plan with no design is a decomposition of
+nothing. Every plan in this repository has an RFC behind it; most fixes have neither.
 
 ## Mapping Issue Content to Documents
 

--- a/plugins/principled-github/skills/triage/SKILL.md
+++ b/plugins/principled-github/skills/triage/SKILL.md
@@ -71,7 +71,7 @@ Process open GitHub issues through the principled pipeline. Finds untriaged issu
 
 4. **Process each issue sequentially.** For each issue in the queue, follow the `/ingest-issue` SKILL.md workflow inline (steps 2–11). This means each issue gets the full treatment:
    - **Metadata normalization** — missing labels, vague titles are fixed on GitHub
-   - **Classification** — determines RFC + Plan vs Plan only
+   - **Classification** — determines RFC + Plan vs no documents at all
    - **Document creation** — proposals and/or plans created, pre-populated from issue content
    - **Issue comment** — links to created documents posted on the issue
    - **Label application** — principled lifecycle labels added
@@ -80,9 +80,9 @@ Process open GitHub issues through the principled pipeline. Finds untriaged issu
 
    ```
    [2/5] Processing #15 — Fix login timeout on slow connections
-         → Classification: Plan only
-         → Created: docs/plans/003-fix-login-timeout.md
-         → Labels: type:plan, plan:active
+         → Classification: No documents (one-PR fix)
+         → Created: nothing; implement directly
+         → Labels: unchanged
    ```
 
 5. **Handle errors gracefully.** If processing an individual issue fails (e.g., network error, permission issue), log the failure and continue to the next issue. Do not abort the entire triage run for a single issue failure.

--- a/plugins/principled-github/skills/triage/reference/triage-guide.md
+++ b/plugins/principled-github/skills/triage/reference/triage-guide.md
@@ -26,7 +26,10 @@ Issues filed by humans are often incomplete. Triage fixes this:
 Delegate to `/ingest-issue` which determines the right document types:
 
 - **RFC + Plan** for features, design changes, architectural work
-- **Plan only** for bugs, fixes, well-scoped improvements
+- **No documents** for bugs, fixes and well-scoped improvements — implement directly and
+  let the PR close the issue. A plan with no proposal is blocked by
+  `check-plan-proposal-link.sh`, and inventing an RFC to get around that puts a fake
+  design on the permanent record.
 
 ### 3. Link Back
 


### PR DESCRIPTION
Closes #37 and #38 — the two protocol defects the first end-to-end run exposed. Both turned out to have evidence-backed answers rather than needing a judgement call.

## #37 — routing by `specializations` never matched

The field is written once (as `[]` in the scaffold), documented once, and read once in prose. **Nothing populates it**, so every agent's is `[]` and routing fell through to `impl-worker` every time while presenting itself as a match.

Dispatch now routes by **`role`**, which the registry already populates and which is stable:

```
AGENT              ROLE          BYTES  SESSIONS   TASKS   SUCCESS
impl-worker        worker         1574         2       5      1.00
issue-ingester     triage          355         0       0       0.0
pr-reviewer        reviewer        349         0       0       0.0
```

With three memory-bearing agents doing three obviously distinct jobs, *learned* specialization was solving a problem that doesn't exist. `specializations` stays in the frontmatter documented as reserved, with RFC-013's `/improve` named as the intended writer.

## #38 — "Plan only" could never be taken

`check-plan-proposal-link.sh` blocks any plan without an accepted proposal (exit 2), so `/ingest-issue`'s second outcome was dead code.

**The evidence says the guard is right and the guidance was wrong:**

- all **13** plans in this repo have an RFC behind them — the pipeline has never produced one without
- **6 of the last 14** merges were fixes that used *neither* an RFC nor a plan

So the missing outcome was never "Plan only" — it's **"no documents at all"**. A plan exists to be executed by `/orchestrate`, `/decompose` or `/spawn`; if nothing will orchestrate the work, the plan is ceremony.

Issue #36 made this concrete: RFC-014 existed largely so Plan-012 could reference it, and **nothing ever orchestrated Plan-012**. I wrote a design document to satisfy a guard.

## Fixed everywhere, not just where the issue pointed

The dead classification appeared in **five** places: `ingest-issue/SKILL.md`, its `classification-guide.md`, `triage/SKILL.md`, its `triage-guide.md`, and the label-application step. All replaced.

A partial fix is exactly what #40 cost us, so I grepped for every occurrence rather than trusting the issue's pointer.

Also: `/agent-dispatch`'s `--local` flow now branches on the classification instead of assuming every issue yields a proposal and plan, and `agent-collaboration.md` records that protocol steps 3–6 apply to design work only.

`just ci` green — 173 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKzFURKGfB1Ec3ayH2hjE2