### PR TITLE
fix: make the memory review gate bind on effect, not just distribution

### DIFF
--- a/docs/architecture/agent-memory.md
+++ b/docs/architecture/agent-memory.md
@@ -91,6 +91,36 @@ uninitialized repository.
 incomplete picture, and the loss is invisible to it. Oversized memory is reported by
 `check-memory-integrity.sh`, never quietly trimmed.
 
+**It reads `HEAD`, not the working tree.** This is what makes the review gate bind on
+_effect_ rather than only on distribution. Reading the working tree meant an uncommitted
+edit reached the very next spawn: an agent could change what every subsequent agent in
+the same run believed, and produce code under that belief, before any reviewer saw a
+diff. Untracked files fall back to the working tree — so a fresh `--init` still works —
+and the fallback announces itself, because silently injecting unreviewed content is the
+behaviour being removed.
+
+### What this does not close
+
+Reading `HEAD` stops an _uncommitted_ edit from taking effect. It does not stop an agent
+that **commits** a memory change on its own branch: that branch's `HEAD` contains it, so
+it is injected for the rest of that run.
+
+Closing that would mean injecting from the default branch instead, which would make
+memory changes untestable before merge — you could not exercise a memory edit on the
+branch that proposes it. The residual is accepted deliberately, and the protection is the
+same one that covers any other code an agent commits: **it does not reach anyone else
+until a human merges it.**
+
+Two further limits worth stating plainly:
+
+- **No `PreToolUse` guard blocks memory writes.** A blocking hook cannot distinguish an
+  agent editing `global.md` from a maintainer curating it, so blocking would stop the
+  human along with the agent. `check-memory-integrity.sh` warns loudly on `global.md`
+  writes instead, and the mechanical protection is the `HEAD` read above.
+- **Nothing verifies that a memory claim is _true_.** The integrity check validates
+  structure and size. A confidently wrong learning passes every automated check in this
+  repository and is injected on every spawn until a human notices.
+
 **Only memory-bearing agents receive anything**, including global memory. `module-auditor`,
 `decision-auditor`, and `boundary-checker` run deterministic scripts and learn nothing by
 definition, so injecting conventions into them spends context for no benefit.

--- a/plugins/principled-agent/hooks/scripts/check-memory-integrity.sh
+++ b/plugins/principled-agent/hooks/scripts/check-memory-integrity.sh
@@ -60,6 +60,24 @@ case "$file_path" in
 */retrospectives/*) exit 0 ;;
 esac
 
+# Global memory is injected into every memory-bearing agent, so a line here costs a
+# line in every agent's context and changes what all of them believe. Say so loudly.
+#
+# This is advisory, not blocking, and deliberately: a PreToolUse guard cannot tell an
+# agent editing this file from a human curating it, so blocking would stop the
+# maintainer along with the agent. The mechanical protection is elsewhere —
+# inject-agent-memory.sh reads HEAD, so nothing here takes effect until it is
+# committed and reviewed.
+case "$file_path" in
+*/memory/global.md)
+  echo "⚠️  Advisory: writing to global agent memory." >&2
+  echo "   global.md is injected into EVERY memory-bearing agent, so this changes what" >&2
+  echo "   all of them believe. It is the highest-blast-radius file in the repository." >&2
+  echo "   Injection reads HEAD, so this takes effect only once committed and merged —" >&2
+  echo "   make sure the reviewer sees it as its own change, not buried in a larger PR." >&2
+  ;;
+esac
+
 # Only memory markdown files past this point.
 case "$file_path" in
 *.md) ;;

--- a/plugins/principled-agent/hooks/scripts/inject-agent-memory.sh
+++ b/plugins/principled-agent/hooks/scripts/inject-agent-memory.sh
@@ -66,25 +66,57 @@ if [[ ! -f "$AGENT_MEMORY" ]]; then
   exit 0
 fi
 
+# Read a memory file as of HEAD, not as it sits in the working tree.
+#
+# This is what makes the ADR-022 review gate bind on EFFECT rather than only on
+# distribution. Reading the working tree meant an uncommitted edit was injected
+# into the very next spawn: an agent could change what every subsequent agent in
+# the same run believed, and produce code under the changed belief, before any
+# reviewer saw a diff. "An agent proposes; a human decides" was true of how memory
+# spreads and false of when it takes hold.
+#
+# Untracked files fall back to the working tree, so a fresh `--init` still works.
+# The fallback is announced, because silently injecting unreviewed content is the
+# behaviour being removed.
+read_memory() {
+  local file="$1"
+  [[ -f "$file" ]] || return 0
+
+  local rel
+  rel="${file#"${REPO_ROOT}/"}"
+
+  if git -C "$REPO_ROOT" cat-file -e "HEAD:${rel}" 2> /dev/null; then
+    git -C "$REPO_ROOT" show "HEAD:${rel}" 2> /dev/null
+    return 0
+  fi
+
+  echo "[uncommitted: ${rel} is not in HEAD; injecting the working-tree copy]"
+  cat "$file"
+}
+
 # Print everything after the closing frontmatter delimiter. Frontmatter is
 # metadata for scripts; the agent only needs the prose.
 emit_body() {
   local file="$1"
   [[ -f "$file" ]] || return 0
-  if [[ "$(head -1 "$file")" != "---" ]]; then
-    cat "$file"
+  local content
+  content="$(read_memory "$file")"
+  [[ -n "$content" ]] || return 0
+
+  if [[ "$(printf '%s\n' "$content" | head -1)" != "---" ]]; then
+    printf '%s\n' "$content"
     return 0
   fi
-  awk '
+  printf '%s\n' "$content" | awk '
     NR == 1 { next }
     !done && /^---[[:space:]]*$/ { done = 1; next }
     done { print }
-  ' "$file"
+  '
 }
 
 {
   echo "=== Accumulated memory for '${agent_id}' ==="
-  echo "Source: .agents/memory/ (committed to git, revisable in review — ADR-020)"
+  echo "Source: .agents/memory/ as of HEAD — uncommitted edits are NOT injected (ADR-020, ADR-022)"
   echo ""
 
   if [[ -f "$GLOBAL_MEMORY" ]]; then

--- a/plugins/principled-agent/lib/agent-memory.sh
+++ b/plugins/principled-agent/lib/agent-memory.sh
@@ -262,6 +262,23 @@ file_size_bytes() {
   wc -c < "$1" | awk '{print $1}'
 }
 
+# Bytes an agent actually receives at spawn: global memory plus its own file.
+#
+# The budget exists to bound CONTEXT, and injection delivers both files
+# (inject-agent-memory.sh). Measuring the agent file alone understated the real
+# payload by the whole size of global.md — 55% of it in this repository — so a
+# file could sit comfortably "under budget" while the agent received far more.
+effective_payload_bytes() {
+  local agent_file="$1" total=0
+  if [[ -f "${MEMORY_DIR}/global.md" ]]; then
+    total=$(($(file_size_bytes "${MEMORY_DIR}/global.md")))
+  fi
+  if [[ -f "$agent_file" ]]; then
+    total=$((total + $(file_size_bytes "$agent_file")))
+  fi
+  echo "$total"
+}
+
 # --- Operation: init -------------------------------------------------------
 if [[ "$OPERATION" == "init" ]]; then
   mkdir -p "$AGENT_MEMORY_DIR" "$RETRO_DIR"
@@ -580,6 +597,29 @@ if [[ "$OPERATION" == "check" ]]; then
   fi
 
   errors=0
+
+  # Global memory is checked first and unconditionally. It is injected into every
+  # memory-bearing agent, which makes it the highest-blast-radius file in the
+  # system — and it was previously never validated at all, because this loop
+  # iterates the registry and global.md has no registry entry.
+  global_file="${MEMORY_DIR}/global.md"
+  if [[ ! -f "$global_file" ]]; then
+    echo "ERROR: global: no file at ${global_file}"
+    errors=$((errors + 1))
+  elif [[ "$(head -1 "$global_file")" != "---" ]]; then
+    echo "ERROR: global: missing YAML frontmatter"
+    errors=$((errors + 1))
+  else
+    global_size="$(file_size_bytes "$global_file")"
+    if [[ "$global_size" -gt "$SOFT_LIMIT_BYTES" ]]; then
+      echo "WARN: global: ${global_size} bytes, over the ${SOFT_LIMIT_BYTES} byte soft budget."
+      echo "      This file is injected into EVERY memory-bearing agent, so a byte here"
+      echo "      costs a byte in every agent's context. Synthesize it down."
+    else
+      echo "OK: global: ${global_size} bytes (injected into every agent)"
+    fi
+  fi
+
   for id in $targets; do
     mem_file="$(agent_memory_path "$id")"
     if [[ ! -f "$mem_file" ]]; then
@@ -600,15 +640,19 @@ if [[ "$OPERATION" == "check" ]]; then
       errors=$((errors + 1))
     fi
 
+    # Budget the payload the agent actually receives — global plus its own file —
+    # not the agent file alone. The budget bounds context, and injection delivers
+    # both.
     size="$(file_size_bytes "$mem_file")"
-    if [[ "$size" -gt "$HARD_LIMIT_BYTES" ]]; then
-      echo "WARN: ${id}: memory is ${size} bytes, over the ${HARD_LIMIT_BYTES} byte budget."
+    payload="$(effective_payload_bytes "$mem_file")"
+    if [[ "$payload" -gt "$HARD_LIMIT_BYTES" ]]; then
+      echo "WARN: ${id}: ${payload} bytes injected (${size} own + global), over the ${HARD_LIMIT_BYTES} byte budget."
       echo "      Every byte is injected at spawn. Synthesize it down; do not truncate."
-    elif [[ "$size" -gt "$SOFT_LIMIT_BYTES" ]]; then
-      echo "WARN: ${id}: memory is ${size} bytes, over the ${SOFT_LIMIT_BYTES} byte soft budget."
+    elif [[ "$payload" -gt "$SOFT_LIMIT_BYTES" ]]; then
+      echo "WARN: ${id}: ${payload} bytes injected (${size} own + global), over the ${SOFT_LIMIT_BYTES} byte soft budget."
       echo "      Consider synthesizing accumulated notes into fewer, denser statements."
     else
-      echo "OK: ${id}: ${size} bytes"
+      echo "OK: ${id}: ${payload} bytes injected (${size} own + global)"
     fi
   done
 

--- a/tests/agent-memory.bats
+++ b/tests/agent-memory.bats
@@ -252,3 +252,67 @@ run_without_jq() {
   without_jq="$(run_without_jq --list | awk 'NR > 1 { print $1 }' | sort)"
   [ "$with_jq" = "$without_jq" ]
 }
+
+# --- Injection reads committed state, not the working tree ---
+#
+# ADR-022 says memory changes go through review. That was true of how memory is
+# distributed and false of when it takes effect: injection read the working tree, so an
+# uncommitted edit reached the very next spawn. An agent could change what every
+# subsequent agent believed, and produce code under the changed belief, before any
+# reviewer saw a diff.
+
+@test "an uncommitted memory edit is not injected" {
+  git add -A && git commit -qm "baseline memory"
+  printf -- '- UNCOMMITTED CLAIM\n' >> "$MEM"
+  run bash -c "cd '$WORK' && echo '{\"agent_id\":\"impl-worker\"}' | bash '${REPO_ROOT}/plugins/principled-agent/hooks/scripts/inject-agent-memory.sh' 2>&1"
+  [ "$status" -eq 0 ]
+  # The whole point: the unreviewed line must not reach the agent.
+  ! echo "$output" | grep -q 'UNCOMMITTED CLAIM'
+}
+
+@test "committed memory is still injected" {
+  printf -- '- COMMITTED CLAIM\n' >> "$MEM"
+  git add -A && git commit -qm "add a learning"
+  run bash -c "cd '$WORK' && echo '{\"agent_id\":\"impl-worker\"}' | bash '${REPO_ROOT}/plugins/principled-agent/hooks/scripts/inject-agent-memory.sh' 2>&1"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'COMMITTED CLAIM'
+}
+
+@test "an untracked memory file still injects, and announces that it is uncommitted" {
+  # A fresh --init must keep working; silence would be the failure mode.
+  run bash -c "cd '$WORK' && echo '{\"agent_id\":\"impl-worker\"}' | bash '${REPO_ROOT}/plugins/principled-agent/hooks/scripts/inject-agent-memory.sh' 2>&1"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'uncommitted'
+}
+
+# --- Global memory is validated and budgeted ---
+
+@test "check validates global memory, which has no registry entry" {
+  run bash "$LIB" --check
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q '^OK: global:'
+}
+
+@test "missing global memory is a structural error" {
+  rm .agents/memory/global.md
+  run bash "$LIB" --check
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q 'ERROR: global:'
+}
+
+@test "the budget counts what injection actually delivers, not the agent file alone" {
+  # Injection sends global + the agent's own file. Budgeting the agent file alone
+  # understated the real payload by the whole size of global.md.
+  run bash "$LIB" --check --agent impl-worker
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'bytes injected'
+  echo "$output" | grep -q 'own + global'
+}
+
+@test "a large global file pushes a small agent over budget" {
+  # An agent file well under budget must still warn when the injected total is not.
+  awk 'BEGIN { for (i = 0; i < 200; i++) print "- a global convention every agent receives." }' >> .agents/memory/global.md
+  run bash "$LIB" --check --agent impl-worker
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'soft budget'
+}


### PR DESCRIPTION
Found by adversarial review of the RFC-013 design (12-agent workflow). **The design itself was refuted 3/3 and is not being built** — but the reviewers verified four defects in already-merged code. I reproduced each before fixing it.

## 1. Uncommitted memory was injected immediately

ADR-022 says memory changes go through review. That was true of how memory is **distributed** and false of when it takes **effect**.

`inject-agent-memory.sh` read the working tree, so an uncommitted edit reached the very next spawn. An agent could change what every subsequent agent in a run believed — and produce code under that belief — before any reviewer saw a diff. Reproduced by appending a line and watching it inject.

Now reads `HEAD`. Untracked files fall back to the working tree so a fresh `--init` still works, and **the fallback announces itself**, because silently injecting unreviewed content is the behaviour being removed.

## 2. `--check` never validated `global.md`

The loop iterates the registry, and global memory has no registry entry. So the file injected into *every* memory-bearing agent — the highest-blast-radius file here — was the one file never checked.

## 3. The budget measured 45% of the payload

Injection delivers global **plus** the agent file. The check measured the agent file alone:

```
before:  OK: impl-worker: 1574 bytes
after:   OK: global: 1955 bytes (injected into every agent)
         OK: impl-worker: 3529 bytes injected (1574 own + global)
```

An 8 KB budget enforced against 45% of the real payload.

## 4. `global.md` writes drew a generic advisory

Now flagged specifically, since a line there changes what every agent believes.

## Deliberately not done

**No `PreToolUse` guard blocking memory writes.** A hook cannot distinguish an agent editing `global.md` from a maintainer curating it, so blocking would stop the human too.

## One reviewer claim did not hold

The metric reconstruction (`prior_ok = ct * cr`) was called a bug that "compounds every session." Measured drift is **0.0014 and bounded**. Left alone, and said so rather than fixing something that isn't broken.

## What remains open, stated in the architecture doc

Reading `HEAD` stops an *uncommitted* edit — not an agent that **commits** on its own branch. Closing that would mean injecting from the default branch, making memory changes untestable before merge. The residual is the same protection as any other agent-written code: it reaches nobody until a human merges.

Also recorded: **nothing verifies a memory claim is true.** Structure and size pass; a confidently wrong learning is injected on every spawn until a human notices.

`just ci` green — **180 tests, up from 173**, 7 new covering each fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKzFURKGfB1Ec3ayH2hjE2