### PR TITLE
docs: reject RFC-013, and record the design workflow retrospective

### DIFF
--- a/.agents/retrospectives/2026-07-28-rfc-013-design-workflow.md
+++ b/.agents/retrospectives/2026-07-28-rfc-013-design-workflow.md
@@ -1,0 +1,68 @@
+---
+date: 2026-07-28
+proposal: "013"
+agent: orchestrator
+mode: workflow
+agents_total: 12
+agents_completed: 10
+agents_errored: 2
+outcome: proposal-rejected
+defects_found_in_shipped_code: 4
+defects_claimed_but_unverified: 1
+---
+
+# Retrospective — the RFC-013 design workflow
+
+A 12-agent workflow run to resolve RFC-013's open questions and design the
+self-improvement loop: five agents on the open questions, three independent designs, one
+judge, three adversarial reviewers.
+
+## Outcome
+
+RFC-013 was **rejected**. All three adversarial lenses refuted the synthesized design.
+
+The workflow's real output was not a design — it was **four verified defects in already
+merged code**, fixed in #44. The most serious: injection read the working tree, so an
+uncommitted memory edit reached the very next spawn. ADR-022's review guarantee was true
+of how memory is distributed and false of when it takes effect.
+
+## What failed, mechanically
+
+**Two of three designs died on the structured-output retry cap.** `DESIGN_SCHEMA` had six
+required fields, several demanding long prose. Both failures were in the same `parallel()`
+call, so the Designs phase returned one result instead of three.
+
+The consequence is worse than losing two agents: **the judge phase compared one surviving
+design against nothing.** It still produced a confident synthesis naming a winner, because
+nothing in the script told it the panel had collapsed — `validDesigns.filter(Boolean)`
+silently returned an array of one, and the prompt said "three independent designs are
+below."
+
+The adversarial phase then refuted a design that had never been scored against
+alternatives. The refutations were substantive and independently verified, so the verdict
+stands — but the comparison the panel existed to provide never happened.
+
+## Lessons
+
+- A judge panel is only as strong as the number of designs that survive. Check
+  `agents_error` and the length of the input array before trusting a synthesis that claims
+  to have compared alternatives.
+- An over-constrained output schema is a silent failure mode in a fan-out: it does not
+  degrade the result, it deletes the agent. Six required fields with long prose values is
+  too many.
+- A prompt that asserts its own inputs ("three designs are below") will be believed by the
+  agent reading it. Interpolate the actual count.
+
+Deliberately **not** promoted to agent memory. These are facts about authoring workflows,
+which only the orchestrating session acts on — not durable knowledge about this codebase
+that an `impl-worker` spawn needs in context. ADR-020's distinction: a retrospective is a
+dated record of one run; memory is undated knowledge asserted as currently true.
+
+## Cost
+
+938k subagent tokens, 220 tool uses, ~25 minutes wall clock, 10 of 12 agents completing.
+
+Whether that was worth it depends on the counterfactual. It did not produce a usable
+design. It did find four real defects in shipped code — including one that made a
+governance guarantee in an accepted ADR false — and it produced a well-argued rejection
+that a future attempt can start from rather than rediscover.

--- a/docs/proposals/013-agent-self-improvement-loop.md
+++ b/docs/proposals/013-agent-self-improvement-loop.md
@@ -1,7 +1,7 @@
 ---
 title: "Agent Self-Improvement Loop"
 number: "013"
-status: draft
+status: rejected
 author: Alex
 created: 2026-07-28
 updated: 2026-07-28
@@ -222,3 +222,64 @@ clone, and it cannot be reviewed or reverted.
   retention policy, or does `/improve` compact them once synthesized?
 - **Delivery order.** Should `/retro` and `/agent-metrics` ship first as read-only
   capability, with `/improve` gated behind evidence that the metrics are trustworthy?
+
+## Rejection
+
+Rejected 2026-07-28, after a 12-agent design workflow resolved the open questions above,
+produced a synthesized design, and then refuted it under three independent adversarial
+lenses. All three refuted. The reasoning is recorded here because the proposal is sound
+in its motivation — performance data really is discarded today — and a future attempt
+should start from these objections rather than rediscover them.
+
+### The three objections
+
+**1. The safety mechanism reproduces the failure it is meant to prevent.**
+
+The design's spine was a per-claim falsifier: an executable test asserting each memory
+item, so a claim that stops being true fails CI. But a falsifier is authored by the same
+agent, in the same session, from the same evidence, as the claim it asserts.
+
+That is precisely the blind spot that cost this repository #40 — where twelve passing
+tests hid a live defect because the test mutated state the same way the check inspected
+it. The lesson is already in `impl-worker` memory. The design would have rebuilt it as a
+safety feature and put a green CI check on top.
+
+**2. It targets a hazard with zero observed instances, and misses the one that occurred.**
+
+Across the 15 items in the live corpus, the count of "memory contained a false claim" is
+zero. The failure that actually happened (#39 → #41) was not a false belief: the contract
+check asked _"does the writing plugin reference this literal anywhere?"_ — a **true**
+predicate, correctly implemented, answering the wrong question. Every memory item could
+have been individually true and that defect still ships. The falsification ledger would
+have been green throughout.
+
+**3. The human gate binds on the commit; belief propagated from the working tree.**
+
+This one was verified against the code and was **real** — an uncommitted memory edit was
+injected into the very next spawn, so "an agent proposes, a human decides" was true of
+distribution and false of effect. Fixed in #44, independently of this proposal.
+
+### What was kept
+
+The workflow's genuine output was not a design. It was four verified defects in shipped
+code, all fixed in #44: injection reading the working tree, `--check` never validating
+`global.md`, the context budget measuring 45% of the real payload, and `global.md` writes
+drawing only a generic advisory.
+
+One reviewer claim did not survive checking — that the metric reconstruction
+`prior_ok = ct * cr` "compounds every session". Measured drift is 0.0014 and bounded.
+
+### What a future attempt would need
+
+Not a better synthesis engine. A **trustworthy fitness signal**, which this repository
+does not yet have — `success_rate` scored the defect-shipping run 1.00, and
+`defects_shipped` / `followup_prs` were added to retrospective frontmatter as a starting
+point, not a solution.
+
+Until a signal exists that distinguishes a run that shipped a latent defect from one that
+did not, an improvement loop optimising against the available metrics would learn most
+confidently from the runs it understands least. The read-only half — `/agent-metrics` and
+richer retrospectives — remains worth building and needs no new proposal to justify it.
+
+This rejection is reversible. A later proposal may supersede it once the signal problem
+is addressed.


### PR DESCRIPTION
## RFC-013 → `rejected`

A 12-agent design workflow resolved its open questions, synthesized a design, then refuted that design under three independent adversarial lenses. **All three refuted.**

The reasoning is written onto the proposal because the *motivation* is sound — performance data really is discarded today — and a future attempt should start from these objections rather than rediscover them.

### The decisive objection

The design's spine was a per-claim **falsifier**: an executable test asserting each memory item, so a claim that goes stale fails CI.

But a falsifier is authored by the same agent, in the same session, from the same evidence, as the claim it asserts. **That is exactly the blind spot that cost us #40** — twelve passing tests hid a live defect because the test mutated state the same way the check inspected it. That lesson is already in `impl-worker` memory. The design would have rebuilt it as a safety feature, with a green CI check on top.

### Two more that landed

- **The hazard has n=0.** Across 15 live memory items, the count of "contained a false claim" is zero. The failure that *did* occur (#39→#41) was a **true** predicate answering the wrong question — structurally invisible to falsification.
- **The gate bound on the commit; belief propagated from the working tree.** Verified and real. Fixed independently in #44.

### What a future attempt needs

Not a better synthesis engine — a **trustworthy fitness signal**, which doesn't exist here yet. `success_rate` scored the defect-shipping run 1.00.

The read-only half (`/agent-metrics`, richer retrospectives) remains worth building and needs no proposal. **The rejection is reversible**; a later proposal may supersede it.

## Workflow retrospective

Two of three designs died on the structured-output retry cap (`DESIGN_SCHEMA` had six required fields demanding long prose). So the judge **compared one surviving design against nothing** — and still named a winner, because the script silently passed an array of one into a prompt asserting "three independent designs are below."

The refutations were substantive and I verified them against the code, so the verdict stands. But the comparison the panel existed to provide never happened, and that's worth writing down.

Lessons recorded:
- check `agents_error` before trusting a synthesis that claims to have compared alternatives
- an over-constrained schema doesn't degrade a fan-out result, it **deletes the agent**
- a prompt asserting its own inputs will be believed — interpolate the real count

**Deliberately not promoted to agent memory.** These are facts about authoring workflows, which only an orchestrating session acts on — not durable knowledge an `impl-worker` spawn needs in context (ADR-020's retrospective/memory distinction).

Cost recorded honestly: 938k subagent tokens, 220 tool uses, ~25 min, 10 of 12 agents completing. It produced no usable design; it found four real defects in shipped code and a well-argued rejection.

`just ci` green — 180 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKzFURKGfB1Ec3ayH2hjE2