### PR TITLE
fix: dedupe the sed -i rule, and announce unreviewed memory at injection

### DIFF
--- a/.agents/memory/agents/impl-worker.md
+++ b/.agents/memory/agents/impl-worker.md
@@ -31,5 +31,3 @@ specializations: []
 - A `case " $list " in *" $item "*)` membership test needs **space** separators. `sort -u`
   and `grep -o` emit newlines, so the glob silently never matches. Normalize with
   `tr '\n' ' '` first.
-- Never use `sed -i` — BSD sed reads the next argument as a backup suffix, so the same
-  invocation behaves differently on macOS and Linux. Use `awk` into a temp file and `mv`.

--- a/docs/architecture/agent-memory.md
+++ b/docs/architecture/agent-memory.md
@@ -105,11 +105,26 @@ Reading `HEAD` stops an _uncommitted_ edit from taking effect. It does not stop 
 that **commits** a memory change on its own branch: that branch's `HEAD` contains it, so
 it is injected for the rest of that run.
 
-Closing that would mean injecting from the default branch instead, which would make
-memory changes untestable before merge — you could not exercise a memory edit on the
-branch that proposes it. The residual is accepted deliberately, and the protection is the
-same one that covers any other code an agent commits: **it does not reach anyone else
-until a human merges it.**
+Closing that outright would mean injecting from the default branch instead, which would
+make memory changes untestable before merge — you could not exercise a memory edit on the
+branch that proposes it. So the hole is **made visible rather than closed**. Injection
+compares what it is about to deliver against the reviewed baseline (`origin/HEAD`,
+falling back through `origin/main`, `main`, `master`) and prefixes the payload when they
+differ:
+
+```
+[UNREVIEWED: .agents/memory/agents/impl-worker.md differs from origin/HEAD.
+             Treat the differences as proposed, not settled.]
+```
+
+A file absent from the baseline entirely is announced as wholly unreviewed. A repository
+with no baseline branch injects normally — an unknown baseline is not a warning.
+
+The content is still delivered, deliberately: an agent must be able to exercise a memory
+change on the branch proposing it. What changes is that an agent acting on unreviewed
+memory now knows that is what it is doing, and the transcript records it. Silence was the
+real defect. The remaining protection is the same one covering any other code an agent
+commits: **it reaches nobody else until a human merges it.**
 
 Two further limits worth stating plainly:
 

--- a/plugins/principled-agent/hooks/scripts/inject-agent-memory.sh
+++ b/plugins/principled-agent/hooks/scripts/inject-agent-memory.sh
@@ -94,6 +94,49 @@ read_memory() {
   cat "$file"
 }
 
+# The reviewed baseline: the default branch, if one is reachable.
+#
+# Reading HEAD stops an *uncommitted* edit from taking effect, but not an agent that
+# commits memory on its own branch — that branch's HEAD contains it, so it is injected
+# for the rest of the run. Injecting from the baseline instead would close that, at the
+# cost of making memory changes untestable on the branch that proposes them.
+#
+# So the hole is made visible rather than closed: if what is being injected differs from
+# the baseline, the agent is told the content is unreviewed. Silent is the failure mode;
+# an agent acting on unreviewed memory should at least know that is what it is doing.
+baseline_ref() {
+  local ref
+  for ref in origin/HEAD origin/main origin/master main master; do
+    if git -C "$REPO_ROOT" rev-parse --verify --quiet "${ref}^{commit}" > /dev/null 2>&1; then
+      echo "$ref"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Emit a warning when a file's committed content differs from the baseline.
+warn_if_unreviewed() {
+  local file="$1" base="$2"
+  [[ -n "$base" ]] || return 0
+
+  local rel
+  rel="${file#"${REPO_ROOT}/"}"
+
+  # Not on the baseline at all — wholly unreviewed.
+  if ! git -C "$REPO_ROOT" cat-file -e "${base}:${rel}" 2> /dev/null; then
+    echo "[UNREVIEWED: ${rel} does not exist on ${base}. This memory has not been merged.]"
+    return 0
+  fi
+
+  local here there
+  here="$(git -C "$REPO_ROOT" rev-parse "HEAD:${rel}" 2> /dev/null || echo "")"
+  there="$(git -C "$REPO_ROOT" rev-parse "${base}:${rel}" 2> /dev/null || echo "")"
+  if [[ -n "$here" && -n "$there" && "$here" != "$there" ]]; then
+    echo "[UNREVIEWED: ${rel} differs from ${base}. Treat the differences as proposed, not settled.]"
+  fi
+}
+
 # Print everything after the closing frontmatter delimiter. Frontmatter is
 # metadata for scripts; the agent only needs the prose.
 emit_body() {
@@ -114,9 +157,15 @@ emit_body() {
   '
 }
 
+BASELINE="$(baseline_ref || true)"
+
 {
   echo "=== Accumulated memory for '${agent_id}' ==="
   echo "Source: .agents/memory/ as of HEAD — uncommitted edits are NOT injected (ADR-020, ADR-022)"
+  if [[ -n "$BASELINE" ]]; then
+    warn_if_unreviewed "$GLOBAL_MEMORY" "$BASELINE"
+    warn_if_unreviewed "$AGENT_MEMORY" "$BASELINE"
+  fi
   echo ""
 
   if [[ -f "$GLOBAL_MEMORY" ]]; then

--- a/tests/agent-memory.bats
+++ b/tests/agent-memory.bats
@@ -316,3 +316,62 @@ run_without_jq() {
   [ "$status" -eq 0 ]
   echo "$output" | grep -q 'soft budget'
 }
+
+# --- Memory committed on a branch is announced as unreviewed ---
+#
+# Reading HEAD stops an uncommitted edit taking effect, but not an agent that COMMITS
+# memory on its own branch. Closing that fully would mean injecting from the default
+# branch, which would make memory changes untestable on the branch proposing them. So
+# the hole is made visible instead: an agent acting on unreviewed memory is told so.
+
+@test "memory matching the baseline injects with no unreviewed warning" {
+  git add -A && git commit -qm "baseline"
+  run bash -c "cd '$WORK' && echo '{\"agent_id\":\"impl-worker\"}' | bash '${REPO_ROOT}/plugins/principled-agent/hooks/scripts/inject-agent-memory.sh' 2>&1"
+  [ "$status" -eq 0 ]
+  ! echo "$output" | grep -q 'UNREVIEWED'
+}
+
+@test "memory committed on a branch is announced as unreviewed" {
+  git add -A && git commit -qm "baseline"
+  git checkout -q -b feature
+  printf -- '- A CLAIM COMMITTED ONLY ON A BRANCH\n' >> "$MEM"
+  git add -A && git commit -qm "agent commits a learning"
+  run bash -c "cd '$WORK' && echo '{\"agent_id\":\"impl-worker\"}' | bash '${REPO_ROOT}/plugins/principled-agent/hooks/scripts/inject-agent-memory.sh' 2>&1"
+  [ "$status" -eq 0 ]
+  # The content is still injected — testability is preserved deliberately...
+  echo "$output" | grep -q 'A CLAIM COMMITTED ONLY ON A BRANCH'
+  # ...but the agent is told it is unreviewed.
+  echo "$output" | grep -q 'UNREVIEWED'
+  echo "$output" | grep -q 'impl-worker.md differs'
+}
+
+@test "a memory file absent from the baseline is announced as wholly unreviewed" {
+  # A brand-new agent memory file, created only on a branch, has never been reviewed.
+  git add -A && git commit -qm "scaffold"
+  git rm -q .agents/memory/agents/pr-reviewer.md
+  git commit -qm "baseline without pr-reviewer"
+  git checkout -q -b feature
+  bash "$LIB" --init > /dev/null
+  git add -A && git commit -qm "agent adds a new memory file on a branch"
+  run bash -c "cd '$WORK' && echo '{\"agent_id\":\"pr-reviewer\"}' | bash '${REPO_ROOT}/plugins/principled-agent/hooks/scripts/inject-agent-memory.sh' 2>&1"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'does not exist on'
+}
+
+@test "no baseline branch at all does not break injection" {
+  # A repository with no main/master/origin must still inject and exit 0.
+  git add -A && git commit -qm "only branch"
+  git branch -m solo-branch
+  run bash -c "cd '$WORK' && echo '{\"agent_id\":\"impl-worker\"}' | bash '${REPO_ROOT}/plugins/principled-agent/hooks/scripts/inject-agent-memory.sh' 2>&1"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'Accumulated memory'
+}
+
+@test "the sed -i rule lives in global memory only, not duplicated per agent" {
+  # It is a repository-wide shell constraint, so global is its home. Duplicating it
+  # into an agent file spends the same bytes twice in that agent's context.
+  run bash -c "grep -c 'sed -i' '${REPO_ROOT}/.agents/memory/agents/impl-worker.md' || true"
+  [ "$output" = "0" ]
+  run bash -c "grep -c 'sed -i' '${REPO_ROOT}/.agents/memory/global.md' || true"
+  [ "$output" -ge 1 ]
+}


### PR DESCRIPTION
The two loose ends I flagged when closing out.

## 1. Deduplicated the `sed -i` rule

It sat in both `global.md` and `impl-worker.md`, so ~180 bytes were injected **twice** into every `impl-worker` spawn. It's a repository-wide shell constraint, so `global.md` is its home and the per-agent copy is gone.

```
before:  impl-worker: 3529 bytes injected (1574 own + global)
after:   impl-worker: 3350 bytes injected (1395 own + global)
```

## 2. Unreviewed memory is now announced

#44 stopped an *uncommitted* edit taking effect. It did **not** stop an agent that **commits** memory on its own branch — that branch's `HEAD` contains it, so it's injected for the rest of the run.

Closing that outright would mean injecting from the default branch, which would make memory changes untestable on the branch proposing them. **So the hole is made visible rather than closed:**

```
[UNREVIEWED: .agents/memory/agents/impl-worker.md differs from origin/HEAD.
             Treat the differences as proposed, not settled.]
```

Injection compares against the reviewed baseline (`origin/HEAD` → `origin/main` → `main` → `master`). A file absent from the baseline is announced as wholly unreviewed. A repo with no baseline injects normally — an unknown baseline isn't a warning — and the hook still always exits 0.

**The content is still delivered, deliberately.** An agent must be able to exercise a memory change on the branch proposing it. What changes is that an agent acting on unreviewed memory *knows* that's what it's doing, and the transcript records it. Silence was the real defect.

## Verification

`just ci` green — **185 tests, up from 180**. Five new:

- baseline match emits no warning
- a branch commit **is** announced, and content still injected
- a file absent from the baseline is announced as wholly unreviewed
- no baseline branch at all doesn't break injection
- the dedupe holds (rule in global, absent from the agent file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKzFURKGfB1Ec3ayH2hjE2