### PR TITLE
chore: reconcile completed plan records, and repair the pre-commit gate

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -124,6 +124,21 @@ ADR-018.
 - Test both paths. `tests/manifest-checkpoint.bats` runs each operation with jq and with
   a PATH that genuinely lacks it, then validates the result with the real jq.
 
+### Changing `.pre-commit-config.yaml`
+
+Every hook in it mirrors a step in `.github/workflows/ci.yml`. Keep them in step, or the
+local gate stops predicting CI — which is the only reason to run it.
+
+- **Do not use `pre-commit/mirrors-prettier`.** It pins its own prettier, which disagrees
+  with the repo's devDependency on Markdown tables containing `|` inside code spans: the
+  mirror rewrites files that CI's prettier reports as clean. Prettier runs as a `local`
+  hook against `npx prettier` for this reason.
+- **Scope shell hooks with `files: \.sh$`.** CI lints `*.sh` only. Unscoped, pre-commit
+  also lints `.bats` files and fails on style CI never checks.
+- Removing a script means removing the hook that calls it. Four hooks kept invoking
+  per-plugin `check-template-drift.sh` scripts that ADR-018 had deleted; each failed with
+  exit 127, and CI never noticed because CI had already dropped those steps.
+
 ### Changing Frontmatter Schema
 
 - Any changes to frontmatter field names or status values must be reflected in `plugins/principled-docs/hooks/scripts/parse-frontmatter.sh` and the guard scripts that consume it.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,53 +1,72 @@
+# Local commit gate. Every hook here mirrors a step in .github/workflows/ci.yml,
+# so a clean `pre-commit run --all-files` means CI will not fail on lint or drift.
+# The bats suite is the deliberate exception — it runs in CI and via `just test`,
+# not on every commit.
 repos:
   - repo: https://github.com/scop/pre-commit-shfmt
     rev: v3.10.0-1
     hooks:
       - id: shfmt
         args: ["-i", "2", "-bn", "-sr", "-d"]
+        # CI lints `*.sh` only. Without this, pre-commit also picks up `.bats`
+        # files, which shfmt formats differently and CI never sees.
+        files: \.sh$
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.10.0.1
     hooks:
       - id: shellcheck
         args: ["--shell=bash"]
+        files: \.sh$
 
   - repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.17.0
     hooks:
       - id: markdownlint-cli2
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
-    hooks:
-      - id: prettier
-        types_or: [markdown]
-
   - repo: local
     hooks:
+      # Prettier runs from this repo's pinned devDependency rather than
+      # pre-commit/mirrors-prettier. The mirror pins its own (older) prettier,
+      # and the two disagree on Markdown tables containing `|` inside code
+      # spans: the mirror rewrites files that CI's prettier considers clean.
+      - id: prettier
+        name: prettier (repo devDependency, matches CI)
+        entry: npx prettier --check
+        language: system
+        types_or: [markdown]
+
       - id: template-drift
-        name: template drift check
+        name: principled-docs template drift check
         entry: bash plugins/principled-docs/skills/scaffold/scripts/check-template-drift.sh
         language: system
         pass_filenames: false
         always_run: true
 
-      - id: impl-template-drift
-        name: implementation plugin template drift check
-        entry: bash plugins/principled-implementation/scripts/check-template-drift.sh
+      - id: cross-plugin-drift
+        name: cross-plugin script drift check (check-gh-cli.sh)
+        entry: bash scripts/check-cross-plugin-drift.sh
         language: system
         pass_filenames: false
         always_run: true
 
-      - id: github-template-drift
-        name: github plugin template drift check
-        entry: bash plugins/principled-github/scripts/check-template-drift.sh
+      - id: skill-references
+        name: skill and hook reference integrity
+        entry: bash scripts/check-skill-references.sh
         language: system
         pass_filenames: false
         always_run: true
 
-      - id: quality-template-drift
-        name: quality plugin template drift check
-        entry: bash plugins/principled-quality/scripts/check-template-drift.sh
+      - id: pipeline-audit
+        name: pipeline audit (numbering, linkage, statuses, supersession)
+        entry: bash scripts/pipeline-audit.sh
+        language: system
+        pass_filenames: false
+        always_run: true
+
+      - id: validate-root
+        name: root documentation structure
+        entry: bash plugins/principled-docs/lib/validate-structure.sh --root
         language: system
         pass_filenames: false
         always_run: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,20 @@ Six agents across four plugins:
 
 The `spawn` skill delegates to `impl-worker` via `context: fork` + `agent: impl-worker` frontmatter. The orchestrator invokes `/spawn` from inline context (no fork) to coordinate multiple sub-agent spawns — sequentially by default, or in parallel via agent teams when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set.
 
+### Two kinds of agent memory
+
+Do not confuse them; they have opposite governance.
+
+- **`memory: project`** (agent frontmatter — `impl-worker` sets it). Claude Code's own
+  per-agent scratch memory, written to `.claude/agent-memory/` and **gitignored**. It is
+  session-local, never reviewed, and never shared. Prune it periodically on long-running
+  projects: nothing expires it, and stale notes are read as current fact.
+- **`.agents/memory/`** (principled-agent). Committed knowledge, injected at spawn by the
+  Agent Memory Injection hook and revised only through a pull request — see
+  [ADR-020](docs/decisions/020-agent-memory-as-document.md) and
+  [ADR-022](docs/decisions/022-agent-governance-constraints.md). This is the durable,
+  reviewed record; the gitignored one is not.
+
 ## Key Conventions
 
 ### Shared Code: `lib/` (ADR-018)

--- a/docs/plans/000-principled-docs.md
+++ b/docs/plans/000-principled-docs.md
@@ -4,7 +4,7 @@ number: "000"
 status: complete
 author: Claude
 created: 2026-02-04
-updated: 2026-02-22
+updated: 2026-07-29
 originating_proposal: "000"
 ---
 
@@ -134,32 +134,32 @@ Tasks are organized by phase, with each phase mapping to one or more bounded con
 
 **Goal:** Create the complete directory tree and write all canonical templates.
 
-- [ ] **1.1** Create `.claude-plugin/plugin.json` with name, version, description, author, homepage, keywords per PRD §5.5
-- [ ] **1.2** Create the full directory skeleton: all skill directories, hook directories, reference directories, template directories, script directories, diagram directories — matching PRD §5.2 exactly
-- [ ] **1.3** Write canonical core templates in `skills/scaffold/templates/core/`:
-  - [ ] `proposal.md` (RFC template per PRD §8.1)
-  - [ ] `plan.md` (DDD implementation plan template per PRD §8.2)
-  - [ ] `decision.md` (ADR template per PRD §8.3)
-  - [ ] `architecture.md` (Architecture doc template per PRD §8.4)
-  - [ ] `README.md` (Module README template per PRD §8.5)
-  - [ ] `CONTRIBUTING.md` (Module CONTRIBUTING template per PRD §8.6)
-  - [ ] `CLAUDE.md` (Module CLAUDE.md template per PRD §8.7)
-- [ ] **1.4** Write canonical lib templates in `skills/scaffold/templates/lib/`:
-  - [ ] `INTERFACE.md` (Interface contract template per PRD §8.8)
-  - [ ] `example.md` (Usage example template per PRD §8.8)
-- [ ] **1.5** Write canonical app templates in `skills/scaffold/templates/app/`:
-  - [ ] `runbook.md` (Runbook template per PRD §8.9)
-  - [ ] `integration.md` (Integration doc template per PRD §8.9)
-  - [ ] `config.md` (Configuration surface template per PRD §8.9)
-- [ ] **1.6** Copy templates to consuming skills per PRD §5.4 drift table:
-  - [ ] `core/proposal.md` → `new-proposal/templates/proposal.md`
-  - [ ] `core/plan.md` → `new-plan/templates/plan.md`
-  - [ ] `core/decision.md` → `new-adr/templates/decision.md`
-  - [ ] `core/architecture.md` → `new-architecture-doc/templates/architecture.md`
-- [ ] **1.7** Copy `next-number.sh` script across skills:
-  - [ ] Write canonical `new-proposal/scripts/next-number.sh`
-  - [ ] Copy to `new-plan/scripts/next-number.sh`
-  - [ ] Copy to `new-adr/scripts/next-number.sh`
+- [x] **1.1** Create `.claude-plugin/plugin.json` with name, version, description, author, homepage, keywords per PRD §5.5
+- [x] **1.2** Create the full directory skeleton: all skill directories, hook directories, reference directories, template directories, script directories, diagram directories — matching PRD §5.2 exactly
+- [x] **1.3** Write canonical core templates in `skills/scaffold/templates/core/`:
+  - [x] `proposal.md` (RFC template per PRD §8.1)
+  - [x] `plan.md` (DDD implementation plan template per PRD §8.2)
+  - [x] `decision.md` (ADR template per PRD §8.3)
+  - [x] `architecture.md` (Architecture doc template per PRD §8.4)
+  - [x] `README.md` (Module README template per PRD §8.5)
+  - [x] `CONTRIBUTING.md` (Module CONTRIBUTING template per PRD §8.6)
+  - [x] `CLAUDE.md` (Module CLAUDE.md template per PRD §8.7)
+- [x] **1.4** Write canonical lib templates in `skills/scaffold/templates/lib/`:
+  - [x] `INTERFACE.md` (Interface contract template per PRD §8.8)
+  - [x] `example.md` (Usage example template per PRD §8.8)
+- [x] **1.5** Write canonical app templates in `skills/scaffold/templates/app/`:
+  - [x] `runbook.md` (Runbook template per PRD §8.9)
+  - [x] `integration.md` (Integration doc template per PRD §8.9)
+  - [x] `config.md` (Configuration surface template per PRD §8.9)
+- [x] **1.6** Copy templates to consuming skills per PRD §5.4 drift table:
+  - [x] `core/proposal.md` → `new-proposal/templates/proposal.md`
+  - [x] `core/plan.md` → `new-plan/templates/plan.md`
+  - [x] `core/decision.md` → `new-adr/templates/decision.md`
+  - [x] `core/architecture.md` → `new-architecture-doc/templates/architecture.md`
+- ~~**1.7** Copy `next-number.sh` script across skills:~~ — **superseded by [ADR-018](../decisions/018-shared-plugin-lib-over-copies.md).** Shipped as a single `lib/next-number.sh` that all three skills reference; there are no copies to keep in step.
+  - ~~Write canonical `new-proposal/scripts/next-number.sh`~~
+  - ~~Copy to `new-plan/scripts/next-number.sh`~~
+  - ~~Copy to `new-adr/scripts/next-number.sh`~~
 
 ### Phase 2: Utility Scripts & Knowledge Base (BC-2, BC-3)
 
@@ -167,60 +167,60 @@ Tasks are organized by phase, with each phase mapping to one or more bounded con
 
 **Depends on:** Phase 1 (directory skeleton and canonical templates exist)
 
-- [ ] **2.1** Implement `hooks/scripts/parse-frontmatter.sh`:
-  - [ ] Accept `--file <path> --field <name>` arguments
-  - [ ] Extract value of named field from YAML frontmatter (between `---` delimiters)
-  - [ ] Output value or empty string if not found
-  - [ ] Handle edge cases: missing frontmatter, missing field, multi-word values
-- [ ] **2.2** Implement `skills/new-proposal/scripts/next-number.sh`:
-  - [ ] Accept `--dir <path>` argument
-  - [ ] Scan directory for files matching `NNN-*.md` pattern
-  - [ ] Return next number, zero-padded to 3 digits
-  - [ ] Handle empty directory (return `001`)
-  - [ ] Handle gaps in sequence (use max + 1, not fill gaps)
-- [ ] **2.3** Implement `skills/scaffold/scripts/validate-structure.sh`:
-  - [ ] Accept `--module-path <path>`, `--type core|lib|app`, `--strict`, `--json`, `--root`, `--on-write` flags
-  - [ ] Define required structure per module type (core base + lib/app extensions)
-  - [ ] Check directory existence, file existence, placeholder detection
-  - [ ] Output human-readable report (with `✓`, `✗`, `~` markers) or JSON
-  - [ ] `--on-write` mode: lightweight check, advisory output only
-  - [ ] `--root` mode: validate repo-level `docs/` structure
-  - [ ] Exit code: 0 for pass, 1 for fail
-- [ ] **2.4** Implement `skills/scaffold/scripts/check-template-drift.sh`:
-  - [ ] Define canonical-to-copy mapping per PRD §5.4 table
-  - [ ] Compare each copy to its canonical source (byte-level diff)
-  - [ ] Report drifted files and exit non-zero if any diverge
-- [ ] **2.5** Copy utility scripts to consuming skills:
-  - [ ] Copy `validate-structure.sh` → `validate/scripts/validate-structure.sh`
-- [ ] **2.6** Write `skills/docs-strategy/reference/structure-spec.md`:
-  - [ ] Core structure: `docs/{proposals,plans,decisions,architecture}/`, `README.md`, `CONTRIBUTING.md`, `CLAUDE.md`
-  - [ ] Lib extensions: `docs/examples/`, `INTERFACE.md`
-  - [ ] App extensions: `docs/{runbooks,integration,config}/`
-  - [ ] Root-level structure: `docs/{proposals,plans,decisions,architecture}/`
-- [ ] **2.7** Write `skills/docs-strategy/reference/component-guide.md`:
-  - [ ] Purpose, audience, content expectations for every component per PRD §4.4
-- [ ] **2.8** Write `skills/docs-strategy/reference/naming-conventions.md`:
-  - [ ] `NNN-short-title.md` pattern, slug rules (lowercase, hyphens, no special chars)
-  - [ ] Zero-padding to 3 digits, sequence numbering rules
-  - [ ] Fixed-name files: README.md, CONTRIBUTING.md, CLAUDE.md, INTERFACE.md
-- [ ] **2.9** Write `skills/docs-strategy/reference/lifecycle-rules.md`:
-  - [ ] Proposal lifecycle: `draft → in-review → accepted|rejected|superseded`
-  - [ ] Plan lifecycle: `active → complete|abandoned`
-  - [ ] ADR lifecycle: `proposed → accepted → deprecated|superseded`
-  - [ ] Immutability rules, `superseded_by` exception
-  - [ ] No transitions from terminal states
-- [ ] **2.10** Write `skills/docs-strategy/reference/ddd-decomposition.md`:
-  - [ ] What bounded contexts are, how to identify them
-  - [ ] What aggregates are, how to define boundaries
-  - [ ] Domain events: what they are, how they flow between contexts
-  - [ ] Task decomposition: deriving concrete implementation tasks from domain analysis
-  - [ ] Practical examples relevant to documentation systems
-- [ ] **2.11** Write `skills/docs-strategy/diagrams/pipeline-overview.md`:
-  - [ ] ASCII/text diagram of Proposals → Decisions → Plans pipeline
-  - [ ] Key relationships and data flow
-- [ ] **2.12** Write `skills/new-plan/reference/ddd-guide.md`:
-  - [ ] Practical guide for plan authors (more concise, action-oriented version of 2.10)
-  - [ ] Step-by-step process for DDD decomposition in the context of a plan
+- [x] **2.1** Implement `hooks/scripts/parse-frontmatter.sh`:
+  - [x] Accept `--file <path> --field <name>` arguments
+  - [x] Extract value of named field from YAML frontmatter (between `---` delimiters)
+  - [x] Output value or empty string if not found
+  - [x] Handle edge cases: missing frontmatter, missing field, multi-word values
+- [x] **2.2** Implement `next-number.sh` (shipped at `lib/next-number.sh`):
+  - [x] Accept `--dir <path>` argument
+  - [x] Scan directory for files matching `NNN-*.md` pattern
+  - [x] Return next number, zero-padded to 3 digits
+  - [x] Handle empty directory (return `001`)
+  - [x] Handle gaps in sequence (use max + 1, not fill gaps)
+- [x] **2.3** Implement `validate-structure.sh` (shipped at `lib/validate-structure.sh`):
+  - [x] Accept `--module-path <path>`, `--type core|lib|app`, `--strict`, `--json`, `--root`, `--on-write` flags
+  - [x] Define required structure per module type (core base + lib/app extensions)
+  - [x] Check directory existence, file existence, placeholder detection
+  - [x] Output human-readable report (with `✓`, `✗`, `~` markers) or JSON
+  - [x] `--on-write` mode: lightweight check, advisory output only
+  - [x] `--root` mode: validate repo-level `docs/` structure
+  - [x] Exit code: 0 for pass, 1 for fail
+- [x] **2.4** Implement `skills/scaffold/scripts/check-template-drift.sh`:
+  - [x] Define canonical-to-copy mapping per PRD §5.4 table
+  - [x] Compare each copy to its canonical source (byte-level diff)
+  - [x] Report drifted files and exit non-zero if any diverge
+- ~~**2.5** Copy utility scripts to consuming skills:~~ — **superseded by [ADR-018](../decisions/018-shared-plugin-lib-over-copies.md).**
+  - ~~Copy `validate-structure.sh` → `validate/scripts/validate-structure.sh`~~ — `validate`, `scaffold`, `docs-audit` and the structure-nudge hook all reference the one copy in `lib/`.
+- [x] **2.6** Write `skills/docs-strategy/reference/structure-spec.md`:
+  - [x] Core structure: `docs/{proposals,plans,decisions,architecture}/`, `README.md`, `CONTRIBUTING.md`, `CLAUDE.md`
+  - [x] Lib extensions: `docs/examples/`, `INTERFACE.md`
+  - [x] App extensions: `docs/{runbooks,integration,config}/`
+  - [x] Root-level structure: `docs/{proposals,plans,decisions,architecture}/`
+- [x] **2.7** Write `skills/docs-strategy/reference/component-guide.md`:
+  - [x] Purpose, audience, content expectations for every component per PRD §4.4
+- [x] **2.8** Write `skills/docs-strategy/reference/naming-conventions.md`:
+  - [x] `NNN-short-title.md` pattern, slug rules (lowercase, hyphens, no special chars)
+  - [x] Zero-padding to 3 digits, sequence numbering rules
+  - [x] Fixed-name files: README.md, CONTRIBUTING.md, CLAUDE.md, INTERFACE.md
+- [x] **2.9** Write `skills/docs-strategy/reference/lifecycle-rules.md`:
+  - [x] Proposal lifecycle: `draft → in-review → accepted|rejected|superseded`
+  - [x] Plan lifecycle: `active → complete|abandoned`
+  - [x] ADR lifecycle: `proposed → accepted → deprecated|superseded`
+  - [x] Immutability rules, `superseded_by` exception
+  - [x] No transitions from terminal states
+- [x] **2.10** Write `skills/docs-strategy/reference/ddd-decomposition.md`:
+  - [x] What bounded contexts are, how to identify them
+  - [x] What aggregates are, how to define boundaries
+  - [x] Domain events: what they are, how they flow between contexts
+  - [x] Task decomposition: deriving concrete implementation tasks from domain analysis
+  - [x] Practical examples relevant to documentation systems
+- [x] **2.11** Write `skills/docs-strategy/diagrams/pipeline-overview.md`:
+  - [x] ASCII/text diagram of Proposals → Decisions → Plans pipeline
+  - [x] Key relationships and data flow
+- [x] **2.12** Write `skills/new-plan/reference/ddd-guide.md`:
+  - [x] Practical guide for plan authors (more concise, action-oriented version of 2.10)
+  - [x] Step-by-step process for DDD decomposition in the context of a plan
 
 ### Phase 3: SKILL.md Files — Scaffolding, Validation, Knowledge (BC-3, BC-4)
 
@@ -228,21 +228,21 @@ Tasks are organized by phase, with each phase mapping to one or more bounded con
 
 **Depends on:** Phase 2 (scripts and reference docs exist)
 
-- [ ] **3.1** Write `skills/docs-strategy/SKILL.md`:
-  - [ ] Frontmatter per PRD §6.1 (background knowledge, `user-invocable: false`)
-  - [ ] Body describes when Claude should consult this skill
-  - [ ] References all files in `reference/` and `diagrams/` with progressive disclosure instructions
-- [ ] **3.2** Write `skills/scaffold/SKILL.md`:
-  - [ ] Frontmatter per PRD §6.2 (user-invocable, allowed-tools)
-  - [ ] Full workflow: parse arguments, determine type, create directories, populate templates, validate
-  - [ ] Document `--root` mode for repo-level structure
-  - [ ] Placeholder replacement rules: `{{MODULE_NAME}}`, `{{MODULE_TYPE}}`, `{{DATE}}`, etc.
-  - [ ] Reference templates and scripts within the skill directory
-- [ ] **3.3** Write `skills/validate/SKILL.md`:
-  - [ ] Frontmatter per PRD §6.8 (user-invocable, allowed-tools)
-  - [ ] Workflow: parse arguments, invoke validation engine, format output
-  - [ ] Document `--strict`, `--json`, `--root` modes
-  - [ ] Report format per PRD §6.8
+- [x] **3.1** Write `skills/docs-strategy/SKILL.md`:
+  - [x] Frontmatter per PRD §6.1 (background knowledge, `user-invocable: false`)
+  - [x] Body describes when Claude should consult this skill
+  - [x] References all files in `reference/` and `diagrams/` with progressive disclosure instructions
+- [x] **3.2** Write `skills/scaffold/SKILL.md`:
+  - [x] Frontmatter per PRD §6.2 (user-invocable, allowed-tools)
+  - [x] Full workflow: parse arguments, determine type, create directories, populate templates, validate
+  - [x] Document `--root` mode for repo-level structure
+  - [x] Placeholder replacement rules: `{{MODULE_NAME}}`, `{{MODULE_TYPE}}`, `{{DATE}}`, etc.
+  - [x] Reference templates and scripts within the skill directory
+- [x] **3.3** Write `skills/validate/SKILL.md`:
+  - [x] Frontmatter per PRD §6.8 (user-invocable, allowed-tools)
+  - [x] Workflow: parse arguments, invoke validation engine, format output
+  - [x] Document `--strict`, `--json`, `--root` modes
+  - [x] Report format per PRD §6.8
 
 ### Phase 4: SKILL.md Files — Authoring Workflows (BC-5)
 
@@ -250,33 +250,33 @@ Tasks are organized by phase, with each phase mapping to one or more bounded con
 
 **Depends on:** Phase 2 (next-number.sh, templates, DDD guide exist)
 
-- [ ] **4.1** Write `skills/new-proposal/SKILL.md`:
-  - [ ] Frontmatter per PRD §6.3 (user-invocable, allowed-tools)
-  - [ ] Workflow: parse title, determine target (module vs root), get next number, create file from template, set frontmatter
-  - [ ] Document `--module <path>` and `--root` flags
-- [ ] **4.2** Write `skills/new-plan/SKILL.md`:
-  - [ ] Frontmatter per PRD §6.4 (user-invocable, allowed-tools)
-  - [ ] Workflow: parse title, require `--from-proposal NNN`, verify proposal is accepted, discover related ADRs, read DDD guide, create from template, pre-populate bounded contexts
-  - [ ] Reference `reference/ddd-guide.md` for decomposition guidance
-  - [ ] Document plan lifecycle states: `active`, `complete`, `abandoned`
-- [ ] **4.3** Write `skills/new-adr/SKILL.md`:
-  - [ ] Frontmatter per PRD §6.5 (user-invocable, allowed-tools)
-  - [ ] Workflow: parse title, optional `--from-proposal NNN` (verify accepted if present), assign number, create from template
-  - [ ] Supersession handling: prompt for superseded ADR, update `superseded_by` on old ADR
-  - [ ] Document `--module <path>` and `--root` flags
-- [ ] **4.4** Write `skills/new-architecture-doc/SKILL.md`:
-  - [ ] Frontmatter per PRD §6.7 (user-invocable, allowed-tools)
-  - [ ] Workflow: parse title, scan decisions/ for related ADRs, create from template with ADR links
-  - [ ] Document `--module <path>` and `--root` flags
-- [ ] **4.5** Write `skills/proposal-status/SKILL.md`:
-  - [ ] Frontmatter per PRD §6.6 (user-invocable, allowed-tools)
-  - [ ] Workflow: parse identifier and target status, load current status, validate against state machine, update frontmatter
-  - [ ] Side-effects: prompt for ADR creation on acceptance, prompt for superseding proposal on supersession
-  - [ ] Reference `reference/valid-transitions.md`
-- [ ] **4.6** Write `skills/proposal-status/reference/valid-transitions.md`:
-  - [ ] Full state machine: `draft → in-review → accepted|rejected|superseded`
-  - [ ] Conditions and side-effects per transition
-  - [ ] Error messages for invalid transitions
+- [x] **4.1** Write `skills/new-proposal/SKILL.md`:
+  - [x] Frontmatter per PRD §6.3 (user-invocable, allowed-tools)
+  - [x] Workflow: parse title, determine target (module vs root), get next number, create file from template, set frontmatter
+  - [x] Document `--module <path>` and `--root` flags
+- [x] **4.2** Write `skills/new-plan/SKILL.md`:
+  - [x] Frontmatter per PRD §6.4 (user-invocable, allowed-tools)
+  - [x] Workflow: parse title, require `--from-proposal NNN`, verify proposal is accepted, discover related ADRs, read DDD guide, create from template, pre-populate bounded contexts
+  - [x] Reference `reference/ddd-guide.md` for decomposition guidance
+  - [x] Document plan lifecycle states: `active`, `complete`, `abandoned`
+- [x] **4.3** Write `skills/new-adr/SKILL.md`:
+  - [x] Frontmatter per PRD §6.5 (user-invocable, allowed-tools)
+  - [x] Workflow: parse title, optional `--from-proposal NNN` (verify accepted if present), assign number, create from template
+  - [x] Supersession handling: prompt for superseded ADR, update `superseded_by` on old ADR
+  - [x] Document `--module <path>` and `--root` flags
+- [x] **4.4** Write `skills/new-architecture-doc/SKILL.md`:
+  - [x] Frontmatter per PRD §6.7 (user-invocable, allowed-tools)
+  - [x] Workflow: parse title, scan decisions/ for related ADRs, create from template with ADR links
+  - [x] Document `--module <path>` and `--root` flags
+- [x] **4.5** Write `skills/proposal-status/SKILL.md`:
+  - [x] Frontmatter per PRD §6.6 (user-invocable, allowed-tools)
+  - [x] Workflow: parse identifier and target status, load current status, validate against state machine, update frontmatter
+  - [x] Side-effects: prompt for ADR creation on acceptance, prompt for superseding proposal on supersession
+  - [x] Reference `reference/valid-transitions.md`
+- [x] **4.6** Write `skills/proposal-status/reference/valid-transitions.md`:
+  - [x] Full state machine: `draft → in-review → accepted|rejected|superseded`
+  - [x] Conditions and side-effects per transition
+  - [x] Error messages for invalid transitions
 
 ### Phase 5: Enforcement Hooks (BC-7)
 
@@ -284,26 +284,26 @@ Tasks are organized by phase, with each phase mapping to one or more bounded con
 
 **Depends on:** Phase 2 (parse-frontmatter.sh exists)
 
-- [ ] **5.1** Implement `hooks/scripts/check-adr-immutability.sh`:
-  - [ ] Read JSON from stdin (`tool_input.file_path`)
-  - [ ] Skip if path does not contain `/decisions/`
-  - [ ] Skip if file does not exist (new creation)
-  - [ ] Read status via `parse-frontmatter.sh`
-  - [ ] If status is `accepted`, `deprecated`, or `superseded`: check if edit is limited to `superseded_by`
-  - [ ] If limited to `superseded_by`: exit 0 (allow)
-  - [ ] Otherwise: exit 2 (block) with descriptive message per PRD §7.2.1
-  - [ ] All other cases: exit 0 (allow)
-- [ ] **5.2** Implement `hooks/scripts/check-proposal-lifecycle.sh`:
-  - [ ] Read JSON from stdin (`tool_input.file_path`)
-  - [ ] Skip if path does not contain `/proposals/`
-  - [ ] Skip if file does not exist (new creation)
-  - [ ] Read status via `parse-frontmatter.sh`
-  - [ ] If status is `accepted`, `rejected`, or `superseded`: exit 2 (block) with descriptive message per PRD §7.2.2
-  - [ ] All other cases: exit 0 (allow)
-- [ ] **5.3** Write `hooks/hooks.json`:
-  - [ ] PreToolUse hooks for Edit|Write: ADR immutability guard, proposal lifecycle guard
-  - [ ] PostToolUse hook for Write: post-write structure nudge
-  - [ ] Exact configuration per PRD §7.1
+- [x] **5.1** Implement `hooks/scripts/check-adr-immutability.sh`:
+  - [x] Read JSON from stdin (`tool_input.file_path`)
+  - [x] Skip if path does not contain `/decisions/`
+  - [x] Skip if file does not exist (new creation)
+  - [x] Read status via `parse-frontmatter.sh`
+  - [x] If status is `accepted`, `deprecated`, or `superseded`: check if edit is limited to `superseded_by`
+  - [x] If limited to `superseded_by`: exit 0 (allow)
+  - [x] Otherwise: exit 2 (block) with descriptive message per PRD §7.2.1
+  - [x] All other cases: exit 0 (allow)
+- [x] **5.2** Implement `hooks/scripts/check-proposal-lifecycle.sh`:
+  - [x] Read JSON from stdin (`tool_input.file_path`)
+  - [x] Skip if path does not contain `/proposals/`
+  - [x] Skip if file does not exist (new creation)
+  - [x] Read status via `parse-frontmatter.sh`
+  - [x] If status is `accepted`, `rejected`, or `superseded`: exit 2 (block) with descriptive message per PRD §7.2.2
+  - [x] All other cases: exit 0 (allow)
+- [x] **5.3** Write `hooks/hooks.json`:
+  - [x] PreToolUse hooks for Edit|Write: ADR immutability guard, proposal lifecycle guard
+  - [x] PostToolUse hook for Write: post-write structure nudge
+  - [x] Exact configuration per PRD §7.1
 
 ### Phase 6: Audit & Documentation (BC-8, Plugin Docs)
 
@@ -311,22 +311,22 @@ Tasks are organized by phase, with each phase mapping to one or more bounded con
 
 **Depends on:** Phases 3, 4, 5 (all skills and hooks exist)
 
-- [ ] **6.1** Write `skills/docs-audit/reference/report-format.md`:
-  - [ ] Per-module result format (module name, type, component status)
-  - [ ] Aggregate statistics: total modules, compliance percentage, common gaps
-  - [ ] Summary vs detailed format differences
-- [ ] **6.2** Write `skills/docs-audit/SKILL.md`:
-  - [ ] Frontmatter per PRD §6.9 (user-invocable, allowed-tools)
-  - [ ] Workflow: discover modules, determine types, run validation per module, aggregate results
-  - [ ] Document `--modules-dir`, `--format summary|detailed`, `--include-root` flags
-  - [ ] Module type detection: read from module's CLAUDE.md or config
-- [ ] **6.3** Write plugin `README.md`:
-  - [ ] Installation instructions (how to add plugin to Claude Code)
-  - [ ] Configuration options per PRD §11
-  - [ ] All 9 skills with usage examples
-  - [ ] All hooks with behavioral descriptions
-  - [ ] CI integration examples per PRD §10
-  - [ ] Template customization via `customTemplatesPath`
+- [x] **6.1** Write `skills/docs-audit/reference/report-format.md`:
+  - [x] Per-module result format (module name, type, component status)
+  - [x] Aggregate statistics: total modules, compliance percentage, common gaps
+  - [x] Summary vs detailed format differences
+- [x] **6.2** Write `skills/docs-audit/SKILL.md`:
+  - [x] Frontmatter per PRD §6.9 (user-invocable, allowed-tools)
+  - [x] Workflow: discover modules, determine types, run validation per module, aggregate results
+  - [x] Document `--modules-dir`, `--format summary|detailed`, `--include-root` flags
+  - [x] Module type detection: read from module's CLAUDE.md or config
+- [x] **6.3** Write plugin `README.md`:
+  - [x] Installation instructions (how to add plugin to Claude Code)
+  - [x] Configuration options per PRD §11
+  - [x] All 9 skills with usage examples
+  - [x] All hooks with behavioral descriptions
+  - [x] CI integration examples per PRD §10
+  - [x] Template customization via `customTemplatesPath`
 
 ---
 
@@ -356,27 +356,27 @@ Architectural decisions that should become ADRs during or after implementation:
 
 ## Acceptance Criteria
 
-- [ ] `/scaffold packages/test-module --type core` creates the complete core documentation structure and passes `/validate`
-- [ ] `/scaffold packages/test-lib --type lib` creates core + lib extensions and passes `/validate`
-- [ ] `/scaffold packages/test-app --type app` creates core + app extensions and passes `/validate`
-- [ ] `/scaffold --root` creates repo-level docs structure and passes `/validate --root`
-- [ ] `/new-proposal test-feature --module packages/test-module` creates `001-test-feature.md` with correct frontmatter and template content
-- [ ] `/new-proposal cross-cutting-change --root` creates proposal at repo root level
-- [ ] `/proposal-status 001 in-review` updates frontmatter; `/proposal-status 001 accepted` updates and prompts for ADR
-- [ ] `/proposal-status 001 accepted` from `draft` fails (cannot skip `in-review`)
-- [ ] `/new-plan test-feature --from-proposal 001` creates `001-test-feature.md` plan with DDD sections and related ADRs pre-populated
-- [ ] `/new-plan` without `--from-proposal` to accepted proposal fails
-- [ ] `/new-adr use-postgres --from-proposal 001` creates ADR linked to proposal
-- [ ] `/new-adr standalone-decision` creates ADR without proposal link
-- [ ] Editing an accepted ADR is blocked by the immutability hook (exit code 2)
-- [ ] Updating `superseded_by` on an accepted ADR is allowed
-- [ ] Editing a proposal with status `accepted`, `rejected`, or `superseded` is blocked
-- [ ] Editing a proposal with status `draft` or `in-review` is allowed
-- [ ] `check-template-drift.sh` passes when all copies match canonical
-- [ ] `check-template-drift.sh` fails when a copy diverges
-- [ ] `/docs-audit --include-root` discovers all modules and produces aggregate compliance report
-- [ ] Plugin README documents all skills, hooks, and configuration options
-- [ ] All skills are self-contained: each directory has everything it needs (SKILL.md, templates, scripts, reference docs)
+- [x] `/scaffold packages/test-module --type core` creates the complete core documentation structure and passes `/validate`
+- [x] `/scaffold packages/test-lib --type lib` creates core + lib extensions and passes `/validate`
+- [x] `/scaffold packages/test-app --type app` creates core + app extensions and passes `/validate`
+- [x] `/scaffold --root` creates repo-level docs structure and passes `/validate --root`
+- [x] `/new-proposal test-feature --module packages/test-module` creates `001-test-feature.md` with correct frontmatter and template content
+- [x] `/new-proposal cross-cutting-change --root` creates proposal at repo root level
+- [x] `/proposal-status 001 in-review` updates frontmatter; `/proposal-status 001 accepted` updates and prompts for ADR
+- [x] `/proposal-status 001 accepted` from `draft` fails (cannot skip `in-review`)
+- [x] `/new-plan test-feature --from-proposal 001` creates `001-test-feature.md` plan with DDD sections and related ADRs pre-populated
+- [x] `/new-plan` without `--from-proposal` to accepted proposal fails
+- [x] `/new-adr use-postgres --from-proposal 001` creates ADR linked to proposal
+- [x] `/new-adr standalone-decision` creates ADR without proposal link
+- [x] Editing an accepted ADR is blocked by the immutability hook (exit code 2)
+- [x] Updating `superseded_by` on an accepted ADR is allowed
+- [x] Editing a proposal with status `accepted`, `rejected`, or `superseded` is blocked
+- [x] Editing a proposal with status `draft` or `in-review` is allowed
+- [x] `check-template-drift.sh` passes when all copies match canonical
+- [x] `check-template-drift.sh` fails when a copy diverges
+- [x] `/docs-audit --include-root` discovers all modules and produces aggregate compliance report
+- [x] Plugin README documents all skills, hooks, and configuration options
+- ~~All skills are self-contained: each directory has everything it needs (SKILL.md, templates, scripts, reference docs)~~ — **superseded by [ADR-018](../decisions/018-shared-plugin-lib-over-copies.md).** Every skill still owns its `SKILL.md`, templates and reference docs; shared scripts moved to `lib/` and are referenced via `${CLAUDE_PLUGIN_ROOT}`.
 
 ---
 
@@ -400,3 +400,30 @@ This plan produces artifacts that map back to PRD sections:
 | §6.9 docs-audit              | Phase 6    | 6.1–6.2          |
 | §10 CI Integration           | Phase 6    | 6.3              |
 | §11 Configuration            | Phase 6    | 6.3              |
+
+---
+
+## Completion Record
+
+Verified 2026-07-29 against the repository. The boxes above were ticked from that
+verification, not from memory of the work.
+
+**Evidence.** All 9 skills exist with their `SKILL.md`, reference docs, diagrams and
+templates. All 12 canonical templates are present under `skills/scaffold/templates/`
+(7 core, 2 lib, 3 app), and the 4 consuming-skill copies match — `check-template-drift.sh`
+reports "Checked 4 file pairs. PASS". The utility scripts run: `validate-structure.sh --root`
+reports PASS over this repo's own docs, and `next-number.sh --dir docs/proposals` returns
+the correct next number. All 8 hooks and `parse-frontmatter.sh` exist and are declared in
+`hooks.json`; `tests/hooks.bats` covers their allow, block, malformed-input and no-jq
+paths. The plugin README documents skills, hooks and configuration.
+
+**Divergences from the plan as written.** One theme, applied in four places:
+tasks 1.7, 2.2, 2.3, 2.5 and the final acceptance criterion described copying
+`next-number.sh` and `validate-structure.sh` into each consuming skill.
+[ADR-018](../decisions/018-shared-plugin-lib-over-copies.md) replaced that with a single
+copy in `lib/`, referenced via `${CLAUDE_PLUGIN_ROOT}`. Those items are struck through
+rather than ticked: the copying was not done, and doing it now would be a regression.
+
+The scaffolding templates are the one thing still deliberately duplicated (each generative
+skill ships the template it writes), which is why tasks 1.6 and 2.4 — the copies and their
+drift checker — remain ticked and their check still runs in CI.

--- a/docs/plans/001-dev-setup-and-dx.md
+++ b/docs/plans/001-dev-setup-and-dx.md
@@ -4,7 +4,7 @@ number: "001"
 status: complete
 author: Alex Nodeland
 created: 2026-02-04
-updated: 2026-02-04
+updated: 2026-07-29
 originating_proposal: "001"
 ---
 
@@ -296,7 +296,7 @@ Architectural decisions that may need to become ADRs during implementation:
 - [x] `prettier --check` passes on all `.md` files
 - [x] `.pre-commit-config.yaml` exists and `pre-commit run --all-files` passes
 - [x] `.github/workflows/ci.yml` exists with `lint-shell`, `lint-markdown`, and `validate` jobs
-- [ ] CI pipeline passes on a clean branch (all three jobs green)
+- [x] CI pipeline passes on a clean branch (all three jobs green — since grown to five: Shell Lint, Markdown Lint, Validate, Tests, Bash 3.2 Compatibility)
 - [x] `.claude/settings.json` exists, is committed, and includes `"plugins": [{"path": "."}]`
 - [x] `.claude/skills/` contains 4 dev skills: `lint`, `test-hooks`, `propagate-templates`, `check-ci` (each with `SKILL.md`)
 - [x] `.claude/CLAUDE.md` exists with development-specific guidance

--- a/docs/plans/007-principled-architecture.md
+++ b/docs/plans/007-principled-architecture.md
@@ -4,7 +4,7 @@ number: "007"
 status: complete
 author: Alex
 created: 2026-02-22
-updated: 2026-07-28
+updated: 2026-07-29
 originating_proposal: "005"
 related_adrs: [003, 014]
 ---
@@ -102,13 +102,13 @@ Tasks are organized by phase, with each phase mapping to one or more bounded con
 
 **Goal:** Create the plugin manifest, directory structure, and marketplace integration.
 
-- [ ] **1.1** Create `plugins/principled-architecture/.claude-plugin/plugin.json` with name `principled-architecture`, version `0.1.0`, description, author, keywords (`architecture`, `adr`, `governance`, `drift-detection`, `module-boundaries`)
-- [ ] **1.2** Create full directory skeleton:
+- [x] **1.1** Create `plugins/principled-architecture/.claude-plugin/plugin.json` with name `principled-architecture`, version `0.1.0`, description, author, keywords (`architecture`, `adr`, `governance`, `drift-detection`, `module-boundaries`)
+- [x] **1.2** Create full directory skeleton:
   - `skills/arch-strategy/`, `skills/arch-map/`, `skills/arch-drift/`, `skills/arch-audit/`, `skills/arch-sync/`, `skills/arch-query/`
   - `hooks/scripts/`
-  - `scripts/` (plugin-level drift checker)
-- [ ] **1.3** Add plugin entry to `.claude-plugin/marketplace.json` with category `architecture`
-- [ ] **1.4** Add `principled-architecture@principled-marketplace` to `.claude/settings.json` enabled plugins
+  - ~~`scripts/` (plugin-level drift checker)~~ — shipped as `lib/` instead ([ADR-018](../decisions/018-shared-plugin-lib-over-copies.md))
+- [x] **1.3** Add plugin entry to `.claude-plugin/marketplace.json` with category `architecture`
+- [x] **1.4** Add `principled-architecture@principled-marketplace` to `.claude/settings.json` enabled plugins
 
 ### Phase 2: Knowledge Base & Module Scanner (BC-2, BC-3)
 
@@ -116,10 +116,10 @@ Tasks are organized by phase, with each phase mapping to one or more bounded con
 
 **Depends on:** Phase 1
 
-- [ ] **2.1** Write `arch-strategy/reference/governance-rules.md`: module dependency direction rules (app → lib → core), override mechanism via CLAUDE.md declarations, enforcement levels (advisory vs. strict), violation severity classification
-- [ ] **2.2** Write `arch-strategy/reference/mapping-conventions.md`: how ADRs declare scope (explicit `scope` section, module path references, frontmatter hints), how the map is constructed, map format and interpretation
-- [ ] **2.3** Write `arch-strategy/SKILL.md`: background knowledge skill, not user-invocable
-- [ ] **2.4** Implement `arch-map/scripts/scan-modules.sh`: find all CLAUDE.md files recursively, parse `## Module Type` section to extract type (`core`, `lib`, `app`), output module inventory as structured list (path, type, name)
+- [x] **2.1** Write `arch-strategy/reference/governance-rules.md`: module dependency direction rules (app → lib → core), override mechanism via CLAUDE.md declarations, enforcement levels (advisory vs. strict), violation severity classification
+- [x] **2.2** Write `arch-strategy/reference/mapping-conventions.md`: how ADRs declare scope (explicit `scope` section, module path references, frontmatter hints), how the map is constructed, map format and interpretation
+- [x] **2.3** Write `arch-strategy/SKILL.md`: background knowledge skill, not user-invocable
+- [x] **2.4** Implement `scan-modules.sh` (shipped at `lib/scan-modules.sh`, shared by `arch-map` and `arch-drift`): find all CLAUDE.md files recursively, parse `## Module Type` section to extract type (`core`, `lib`, `app`), output module inventory as structured list (path, type, name)
 
 ### Phase 3: Architecture Map Skill (BC-3)
 
@@ -127,8 +127,8 @@ Tasks are organized by phase, with each phase mapping to one or more bounded con
 
 **Depends on:** Phase 2
 
-- [ ] **3.1** Create `arch-map/templates/arch-map.md`: template with `{{MODULES}}` sections, each containing governing ADRs, architecture doc references, and coverage classification
-- [ ] **3.2** Write `arch-map/SKILL.md`: user-invocable, accepts `--module <path>` and `--output <path>`, runs `scan-modules.sh`, reads all ADRs in `docs/decisions/` and scans body for module path references, reads architecture docs in `docs/architecture/` for module references, cross-references to produce the map, renders via template
+- [x] **3.1** Create `arch-map/templates/arch-map.md`: template with `{{MODULES}}` sections, each containing governing ADRs, architecture doc references, and coverage classification
+- [x] **3.2** Write `arch-map/SKILL.md`: user-invocable, accepts `--module <path>` and `--output <path>`, runs `scan-modules.sh`, reads all ADRs in `docs/decisions/` and scans body for module path references, reads architecture docs in `docs/architecture/` for module references, cross-references to produce the map, renders via template
 
 ### Phase 4: Drift Detection Skill (BC-4)
 
@@ -136,8 +136,8 @@ Tasks are organized by phase, with each phase mapping to one or more bounded con
 
 **Depends on:** Phase 3
 
-- [ ] **4.1** Implement `arch-drift/scripts/check-boundaries.sh`: accept `--module <path>` and `--type <module-type>`, scan source files for import/require/from statements via regex, check import paths against dependency direction rules, output violations with severity and governing ADR reference
-- [ ] **4.2** Write `arch-drift/SKILL.md`: user-invocable, accepts `--module <path>` and `--strict`, builds architecture map (or reads cached), for each accepted ADR extracts constraints, runs `check-boundaries.sh` per module, classifies findings (error/warning/info), reports violations with ADR references, `--strict` mode exits non-zero on any error
+- [x] **4.1** Implement `arch-drift/scripts/check-boundaries.sh`: accept `--module <path>` and `--type <module-type>`, scan source files for import/require/from statements via regex, check import paths against dependency direction rules, output violations with severity and governing ADR reference
+- [x] **4.2** Write `arch-drift/SKILL.md`: user-invocable, accepts `--module <path>` and `--strict`, builds architecture map (or reads cached), for each accepted ADR extracts constraints, runs `check-boundaries.sh` per module, classifies findings (error/warning/info), reports violations with ADR references, `--strict` mode exits non-zero on any error
 
 ### Phase 5: Coverage Audit & Architecture Sync Skills (BC-5)
 
@@ -145,10 +145,10 @@ Tasks are organized by phase, with each phase mapping to one or more bounded con
 
 **Depends on:** Phase 3
 
-- [ ] **5.1** Create `arch-audit/templates/audit-report.md`: template with coverage summary table, ungoverned modules list, orphaned ADRs, stale architecture docs, severity classification
-- [ ] **5.2** Write `arch-audit/SKILL.md`: user-invocable, accepts `--module <path>`, uses architecture map to find: modules with no ADRs, modules with no architecture doc mentions, ADRs referencing removed modules, architecture docs referencing removed components, generates audit report via template with severity classification (critical/warning/info)
-- [ ] **5.3** Implement `arch-sync/scripts/detect-changes.sh`: compare architecture doc content against actual codebase state — module list, module types, component inventory — output discrepancies
-- [ ] **5.4** Write `arch-sync/SKILL.md`: user-invocable, accepts `--doc <path>` and `--all`, reads architecture doc, runs `detect-changes.sh`, proposes updates as inline edits for human review, never auto-modifies (architecture docs require approval)
+- [x] **5.1** Create `arch-audit/templates/audit-report.md`: template with coverage summary table, ungoverned modules list, orphaned ADRs, stale architecture docs, severity classification
+- [x] **5.2** Write `arch-audit/SKILL.md`: user-invocable, accepts `--module <path>`, uses architecture map to find: modules with no ADRs, modules with no architecture doc mentions, ADRs referencing removed modules, architecture docs referencing removed components, generates audit report via template with severity classification (critical/warning/info)
+- [x] **5.3** Implement `arch-sync/scripts/detect-changes.sh`: compare architecture doc content against actual codebase state — module list, module types, component inventory — output discrepancies
+- [x] **5.4** Write `arch-sync/SKILL.md`: user-invocable, accepts `--doc <path>` and `--all`, reads architecture doc, runs `detect-changes.sh`, proposes updates as inline edits for human review, never auto-modifies (architecture docs require approval)
 
 ### Phase 6: Query Skill (BC-6)
 
@@ -156,7 +156,7 @@ Tasks are organized by phase, with each phase mapping to one or more bounded con
 
 **Depends on:** Phase 3
 
-- [ ] **6.1** Write `arch-query/SKILL.md`: user-invocable, accepts `"<question>"`, searches ADRs, architecture docs, proposals, and codebase to find relevant information, synthesizes answer with document references, designed for onboarding and architecture exploration
+- [x] **6.1** Write `arch-query/SKILL.md`: user-invocable, accepts `"<question>"`, searches ADRs, architecture docs, proposals, and codebase to find relevant information, synthesizes answer with document references, designed for onboarding and architecture exploration
 
 ### Phase 7: Hook, Drift Detection & Documentation (BC-1, BC-6)
 
@@ -164,14 +164,14 @@ Tasks are organized by phase, with each phase mapping to one or more bounded con
 
 **Depends on:** Phases 3, 4, 5, 6
 
-- [ ] **7.1** Implement `hooks/scripts/check-boundary-violation.sh`: PostToolUse hook for Write, reads stdin JSON `tool_input.file_path`, determines if file is in a module directory (check for CLAUDE.md in parent hierarchy), if in module: read module type, scan written file for imports, check against dependency direction rules, warn on violations, advisory only (always exits 0)
-- [ ] **7.2** Write `hooks/hooks.json`: PostToolUse hook for Write targeting boundary violation check script
-- [ ] **7.3** Copy `check-gh-cli.sh` from principled-github canonical source to skills that need gh CLI access (if any skills require it — `arch-sync` may use `gh` for PR-based updates). If no skills need gh CLI, skip this step.
-- [ ] **7.4** Implement `scripts/check-template-drift.sh`: verify any cross-plugin or intra-plugin script copies match canonical sources
-- [ ] **7.5** Write plugin `README.md`: installation, skills table, hook, dependency direction rules, architecture map format, governance feedback loop, drift detection approach
-- [ ] **7.6** Update `.github/workflows/ci.yml`: add principled-architecture drift check step (if applicable)
-- [ ] **7.7** Update root `CLAUDE.md`: add principled-architecture to architecture table, skills table, conventions, hooks, testing, dogfooding, dependencies
-- [ ] **7.8** Update `.claude/CLAUDE.md`: add principled-architecture dogfooding section and common pitfalls
+- [x] **7.1** Implement `hooks/scripts/check-boundary-violation.sh`: PostToolUse hook for Write, reads stdin JSON `tool_input.file_path`, determines if file is in a module directory (check for CLAUDE.md in parent hierarchy), if in module: read module type, scan written file for imports, check against dependency direction rules, warn on violations, advisory only (always exits 0)
+- [x] **7.2** Write `hooks/hooks.json`: PostToolUse hook for Write targeting boundary violation check script
+- [x] **7.3** Copy `check-gh-cli.sh` from principled-github canonical source to skills that need gh CLI access (if any skills require it — `arch-sync` may use `gh` for PR-based updates). If no skills need gh CLI, skip this step. — **skipped by its own condition:** `arch-sync` proposes edits for human review and never calls `gh`, so no skill in this plugin needs the check.
+- ~~**7.4** Implement `scripts/check-template-drift.sh`: verify any cross-plugin or intra-plugin script copies match canonical sources~~ — **superseded by [ADR-018](../decisions/018-shared-plugin-lib-over-copies.md).** This plugin has no script copies; `scripts/check-skill-references.sh` verifies the `lib/` references instead.
+- [x] **7.5** Write plugin `README.md`: installation, skills table, hook, dependency direction rules, architecture map format, governance feedback loop, drift detection approach
+- [x] **7.6** Update `.github/workflows/ci.yml`: add principled-architecture drift check step (if applicable) — **not applicable:** no copies to drift-check. CI covers this plugin through `check-skill-references.sh` and the structure/manifest validation jobs.
+- [x] **7.7** Update root `CLAUDE.md`: add principled-architecture to architecture table, skills table, conventions, hooks, testing, dogfooding, dependencies
+- [x] **7.8** Update `.claude/CLAUDE.md`: add principled-architecture dogfooding section and common pitfalls
 
 ---
 
@@ -208,20 +208,47 @@ Open decisions to resolve during implementation:
 
 ## Acceptance Criteria
 
-- [ ] `/arch-map` generates a complete map linking every module to its governing ADRs and architecture docs
-- [ ] `/arch-map --module <path>` scopes output to a single module
-- [ ] Architecture map classifies each module's coverage as Full, Partial, or None
-- [ ] `/arch-drift` detects dependency direction violations (e.g., `core` importing from `app`)
-- [ ] `/arch-drift --module <path>` scopes analysis to a single module
-- [ ] `/arch-drift --strict` exits non-zero when any error-severity violation exists
-- [ ] `/arch-drift` references the governing ADR for each reported violation
-- [ ] `/arch-audit` identifies modules with no ADRs and no architecture doc mentions
-- [ ] `/arch-audit` identifies orphaned ADRs (referencing modules no longer present)
-- [ ] `/arch-audit` identifies stale architecture docs (referencing removed components)
-- [ ] `/arch-audit` classifies findings by severity (critical/warning/info)
-- [ ] `/arch-sync --doc <path>` proposes updates to a single architecture doc for human review
-- [ ] `/arch-sync` never auto-modifies architecture docs — always requires approval
-- [ ] `/arch-query "<question>"` answers natural-language architecture questions with document references
-- [ ] `check-boundary-violation.sh` warns when a written file contains imports violating dependency direction (advisory, never blocks)
-- [ ] `scan-modules.sh` correctly discovers modules by CLAUDE.md and parses module type
-- [ ] Plugin README documents all skills, hook, dependency rules, and governance feedback loop
+- [x] `/arch-map` generates a complete map linking every module to its governing ADRs and architecture docs
+- [x] `/arch-map --module <path>` scopes output to a single module
+- [x] Architecture map classifies each module's coverage as Full, Partial, or None
+- [x] `/arch-drift` detects dependency direction violations (e.g., `core` importing from `app`)
+- [x] `/arch-drift --module <path>` scopes analysis to a single module
+- [x] `/arch-drift --strict` exits non-zero when any error-severity violation exists
+- [x] `/arch-drift` references the governing ADR for each reported violation
+- [x] `/arch-audit` identifies modules with no ADRs and no architecture doc mentions
+- [x] `/arch-audit` identifies orphaned ADRs (referencing modules no longer present)
+- [x] `/arch-audit` identifies stale architecture docs (referencing removed components)
+- [x] `/arch-audit` classifies findings by severity (critical/warning/info)
+- [x] `/arch-sync --doc <path>` proposes updates to a single architecture doc for human review
+- [x] `/arch-sync` never auto-modifies architecture docs — always requires approval
+- [x] `/arch-query "<question>"` answers natural-language architecture questions with document references
+- [x] `check-boundary-violation.sh` warns when a written file contains imports violating dependency direction (advisory, never blocks)
+- [x] `scan-modules.sh` correctly discovers modules by CLAUDE.md and parses module type
+- [x] Plugin README documents all skills, hook, dependency rules, and governance feedback loop
+
+---
+
+## Completion Record
+
+Verified 2026-07-29 against the repository. The boxes above were ticked from that
+verification, not from memory of the work.
+
+**Evidence.** All 6 skills present under `plugins/principled-architecture/skills/`, each
+with its `SKILL.md`; `arch-map` and `arch-audit` ship their templates, `arch-drift` ships
+`check-boundaries.sh` and `arch-sync` ships `detect-changes.sh`. `lib/scan-modules.sh`
+runs and correctly reports module paths and types. The advisory hook and `hooks.json`
+exist, the plugin is registered in `marketplace.json` and enabled in `.claude/settings.json`,
+and both `CLAUDE.md` files document it. `tests/hooks.bats` covers the boundary hook.
+
+**Divergences from the plan as written.** Two, both deliberate:
+
+1. **Shared code.** `scan-modules.sh` was planned under `arch-map/scripts/` and shipped
+   in `lib/`, because `arch-drift` needs it too — [ADR-018](../decisions/018-shared-plugin-lib-over-copies.md).
+   Task 7.4's per-plugin drift checker was never written and should not be: with one copy
+   there is nothing to compare.
+2. **Two conditional tasks resolved to "skip."** 7.3 (`check-gh-cli.sh`) and 7.6 (a CI
+   drift step) were both written as "if applicable"; neither applied. They are marked
+   above with the condition that decided them rather than left ambiguous.
+
+The `boundary-checker` agent in this plugin was added later by
+[Plan-008](008-hooks-subagents-agent-teams.md), not by this plan.

--- a/docs/plans/008-hooks-subagents-agent-teams.md
+++ b/docs/plans/008-hooks-subagents-agent-teams.md
@@ -4,7 +4,7 @@ number: "008"
 status: complete
 author: Alex
 created: 2026-02-23
-updated: 2026-07-28
+updated: 2026-07-29
 originating_proposal: "008"
 related_adrs: "015, 016"
 ---
@@ -123,7 +123,7 @@ Tasks are organized by phase, with each phase mapping to one or more bounded con
 
 **Goal:** Close the three critical enforcement gaps in pipeline document creation.
 
-- [ ] **1.1** Implement `plugins/principled-docs/hooks/scripts/check-plan-proposal-link.sh`:
+- [x] **1.1** Implement `plugins/principled-docs/hooks/scripts/check-plan-proposal-link.sh`:
   - Read stdin JSON, extract `file_path` (jq with grep fallback)
   - Check if file is in `*/plans/*.md`; exit 0 if not
   - Check if file already exists; exit 0 if new file creation (let frontmatter guard handle field presence)
@@ -132,7 +132,7 @@ Tasks are organized by phase, with each phase mapping to one or more bounded con
   - Extract proposal `status` via `parse-frontmatter.sh`
   - Exit 2 if proposal doesn't exist or status is not `accepted`; exit 0 otherwise
 
-- [ ] **1.2** Implement `plugins/principled-docs/hooks/scripts/check-required-frontmatter.sh`:
+- [x] **1.2** Implement `plugins/principled-docs/hooks/scripts/check-required-frontmatter.sh`:
   - Read stdin JSON, extract `file_path`
   - Determine document type from path: `*/proposals/*.md`, `*/plans/*.md`, `*/decisions/*.md`
   - Exit 0 if file doesn't match any pipeline document pattern
@@ -143,7 +143,7 @@ Tasks are organized by phase, with each phase mapping to one or more bounded con
     - Decisions: `status` in `(proposed|accepted|deprecated|superseded)`
   - Exit 2 with descriptive message listing missing/invalid fields; exit 0 if valid
 
-- [ ] **1.3** Implement `plugins/principled-docs/hooks/scripts/check-doc-numbering.sh`:
+- [x] **1.3** Implement `plugins/principled-docs/hooks/scripts/check-doc-numbering.sh`:
   - Read stdin JSON, extract `file_path`
   - Check if file matches `*/proposals/NNN-*.md`, `*/plans/NNN-*.md`, or `*/decisions/NNN-*.md`
   - Exit 0 if pattern doesn't match
@@ -152,13 +152,13 @@ Tasks are organized by phase, with each phase mapping to one or more bounded con
   - Exit 0 if no duplicates found or if the only match is the file itself (re-write)
   - Exit 2 if a different file with the same number exists
 
-- [ ] **1.4** Update `plugins/principled-docs/hooks/hooks.json`:
+- [x] **1.4** Update `plugins/principled-docs/hooks/hooks.json`:
   - Add `check-plan-proposal-link.sh` as PreToolUse guard on `Write`
   - Add `check-required-frontmatter.sh` as PreToolUse guard on `Edit|Write`
   - Add `check-doc-numbering.sh` as PreToolUse guard on `Write`
   - Preserve existing ADR immutability and proposal lifecycle guards
 
-- [ ] **1.5** Write tests for all three guard hooks:
+- [x] **1.5** Write tests for all three guard hooks:
   - Test each hook with valid and invalid inputs
   - Verify exit codes: 0 for allow, 2 for block
   - Test edge cases: non-pipeline files, new file creation, re-write of same file
@@ -170,41 +170,41 @@ Tasks are organized by phase, with each phase mapping to one or more bounded con
 
 **Depends on:** Phase 1
 
-- [ ] **2.1** Implement `plugins/principled-implementation/hooks/scripts/setup-impl-worktree.sh`:
+- [x] **2.1** Implement `plugins/principled-implementation/hooks/scripts/setup-impl-worktree.sh`:
   - Read stdin JSON (WorktreeCreate event context)
   - Check if an active `.impl/manifest.json` exists in the main worktree
   - If manifest exists, create `.impl/` directory in the new worktree with a symlink or copy of the manifest
   - Always exit 0 (advisory, never blocks worktree creation)
 
-- [ ] **2.2** Implement `plugins/principled-implementation/hooks/scripts/cleanup-impl-worktree.sh`:
+- [x] **2.2** Implement `plugins/principled-implementation/hooks/scripts/cleanup-impl-worktree.sh`:
   - Read stdin JSON (WorktreeRemove event context)
   - Extract worktree path
   - If `.impl/` exists in the worktree, archive any logs to main worktree's `.impl/logs/`
   - Update manifest if a task was associated with this worktree
   - Always exit 0 (advisory)
 
-- [ ] **2.3** Implement `plugins/principled-implementation/hooks/scripts/validate-worker-completion.sh`:
+- [x] **2.3** Implement `plugins/principled-implementation/hooks/scripts/validate-worker-completion.sh`:
   - Read stdin JSON (SubagentStop event context with agent name)
   - Filter: only act on `impl-worker` agents, exit 0 for others
   - Check manifest for tasks in `in_progress` status that match the completed agent's context
   - If tasks remain `in_progress` with no status update, exit 2 with message explaining the worker failed to update the manifest
   - If tasks were properly transitioned, exit 0
 
-- [ ] **2.4** Implement `plugins/principled-implementation/hooks/scripts/gate-task-completion.sh`:
+- [x] **2.4** Implement `plugins/principled-implementation/hooks/scripts/gate-task-completion.sh`:
   - Read stdin JSON (TaskCompleted event context with `task_id`)
   - Look up task in `.impl/manifest.json`
   - Verify `check_results` field is populated and all checks passed
   - Exit 2 if checks haven't run or failed; exit 0 if checks passed
   - Only active when agent teams are enabled
 
-- [ ] **2.5** Update `plugins/principled-implementation/hooks/hooks.json`:
+- [x] **2.5** Update `plugins/principled-implementation/hooks/hooks.json`:
   - Add `setup-impl-worktree.sh` on `WorktreeCreate`
   - Add `cleanup-impl-worktree.sh` on `WorktreeRemove`
   - Add `validate-worker-completion.sh` on `SubagentStop`
   - Add `gate-task-completion.sh` on `TaskCompleted`
   - Preserve existing manifest integrity advisory
 
-- [ ] **2.6** Write tests for lifecycle hooks:
+- [x] **2.6** Write tests for lifecycle hooks:
   - Test WorktreeCreate with and without active manifest
   - Test WorktreeRemove cleanup behavior
   - Test SubagentStop with proper and improper task transitions
@@ -216,7 +216,7 @@ Tasks are organized by phase, with each phase mapping to one or more bounded con
 
 **Depends on:** Phase 1
 
-- [ ] **3.1** Implement `plugins/principled-docs/hooks/scripts/async-drift-check.sh`:
+- [x] **3.1** Implement `plugins/principled-docs/hooks/scripts/async-drift-check.sh`:
   - Read stdin JSON, extract `file_path` from PostToolUse Write response
   - Check if file is within `plugins/*/skills/*/scripts/` or `plugins/*/skills/*/templates/`
   - Exit 0 immediately if not a template/script path
@@ -225,12 +225,12 @@ Tasks are organized by phase, with each phase mapping to one or more bounded con
   - Output drift warnings to stderr (surfaced on next conversation turn via async)
   - Always exit 0 (advisory)
 
-- [ ] **3.2** Configure async drift hook in `plugins/principled-docs/hooks/hooks.json`:
+- [x] **3.2** Configure async drift hook in `plugins/principled-docs/hooks/hooks.json`:
   - Add PostToolUse hook on `Write` with `async: true`
   - Matcher: `Write` tool
   - Script: `async-drift-check.sh`
 
-- [ ] **3.3** Implement `plugins/principled-docs/hooks/scripts/check-adr-supersession.sh`:
+- [x] **3.3** Implement `plugins/principled-docs/hooks/scripts/check-adr-supersession.sh`:
   - Read stdin JSON, extract `file_path` from PostToolUse Write response
   - Check if file is in `*/decisions/*.md`; exit 0 if not
   - Extract `superseded_by` field via `parse-frontmatter.sh`
@@ -241,7 +241,7 @@ Tasks are organized by phase, with each phase mapping to one or more bounded con
   - Output warnings to stderr (advisory)
   - Always exit 0
 
-- [ ] **3.4** Add `check-adr-supersession.sh` to `plugins/principled-docs/hooks/hooks.json` as PostToolUse advisory on `Write`
+- [x] **3.4** Add `check-adr-supersession.sh` to `plugins/principled-docs/hooks/hooks.json` as PostToolUse advisory on `Write`
 
 ### Phase 4: Subagent Definitions (BC-4)
 
@@ -249,30 +249,30 @@ Tasks are organized by phase, with each phase mapping to one or more bounded con
 
 **Depends on:** Phase 1
 
-- [ ] **4.1** Create `plugins/principled-docs/agents/module-auditor.md`:
+- [x] **4.1** Create `plugins/principled-docs/agents/module-auditor.md`:
   - Frontmatter: name, description, tools (Read, Glob, Grep, Bash), model (haiku), background (true), maxTurns (50)
   - System prompt: validate documentation structure for assigned modules, run `validate-structure.sh`, report per-module compliance
   - Reference the module type system (ADR-003) and validation criteria
 
-- [ ] **4.2** Create `plugins/principled-docs/agents/decision-auditor.md`:
+- [x] **4.2** Create `plugins/principled-docs/agents/decision-auditor.md`:
   - Frontmatter: name, description, tools (Read, Glob, Grep), model (haiku), background (true), maxTurns (30)
   - System prompt: scan all ADRs, check supersession chains, detect orphaned references, validate status transitions
   - Reference ADR lifecycle rules
 
-- [ ] **4.3** Create `plugins/principled-github/agents/issue-ingester.md`:
+- [x] **4.3** Create `plugins/principled-github/agents/issue-ingester.md`:
   - Frontmatter: name, description, tools (Read, Write, Bash, Glob, Grep), model (inherit), maxTurns (30), skills (github-strategy)
   - System prompt: process a single GitHub issue through the triage pipeline — normalize, classify, create documents, apply labels
 
-- [ ] **4.4** Create `plugins/principled-quality/agents/pr-reviewer.md`:
+- [x] **4.4** Create `plugins/principled-quality/agents/pr-reviewer.md`:
   - Frontmatter: name, description, tools (Read, Glob, Grep, Bash), model (inherit), background (true), maxTurns (50), skills (quality-strategy)
   - System prompt: perform comprehensive review of a single PR — checklist, context, coverage, summary — and return synthesized report
 
-- [ ] **4.5** Create `plugins/principled-architecture/agents/boundary-checker.md`:
+- [x] **4.5** Create `plugins/principled-architecture/agents/boundary-checker.md`:
   - Frontmatter: name, description, tools (Read, Glob, Grep), model (haiku), background (true), maxTurns (30)
   - System prompt: scan assigned modules for architectural boundary violations using import analysis, report violations with ADR references
   - Reference the heuristic governance model (ADR-014)
 
-- [ ] **4.6** Update each plugin's `.claude-plugin/plugin.json` to reference their new agents directory (if not already present)
+- [x] **4.6** Update each plugin's `.claude-plugin/plugin.json` to reference their new agents directory (if not already present)
 
 ### Phase 5: Agent Frontmatter Upgrades (BC-5)
 
@@ -280,21 +280,22 @@ Tasks are organized by phase, with each phase mapping to one or more bounded con
 
 **Depends on:** Phases 2, 4
 
-- [ ] **5.1** Update `plugins/principled-implementation/agents/impl-worker.md`:
+- [x] **5.1** Update `plugins/principled-implementation/agents/impl-worker.md`:
   - Add `maxTurns: 100` to prevent runaway execution
   - Add `memory: project` for cross-session knowledge accumulation
   - Add scoped `hooks` with Stop event for `validate-worker-completion.sh`
   - Use `$CLAUDE_PLUGIN_ROOT` for portable script paths
   - Preserve existing fields: name, description, isolation, tools, skills
 
-- [ ] **5.2** Add `.claude/agent-memory/` to `.gitignore`:
+- [x] **5.2** Add `.claude/agent-memory/` to `.gitignore`:
   - Agent memory is session-local knowledge, not shared repository state
   - Add comment explaining the entry
 
-- [ ] **5.3** Document agent memory governance in root `CLAUDE.md`:
+- [x] **5.3** Document agent memory governance in root `CLAUDE.md`:
   - Add section explaining `memory: project` field and its purpose
   - Note that memory files are gitignored and session-local
   - Recommend periodic pruning for long-running projects
+  - _Completed 2026-07-29 — this was the one task in this plan left genuinely undone. See "Two kinds of agent memory" in root `CLAUDE.md`; it also draws the line against `.agents/memory/`, which did not exist when this plan was written._
 
 ### Phase 6: Agent Teams Integration (BC-6)
 
@@ -302,28 +303,28 @@ Tasks are organized by phase, with each phase mapping to one or more bounded con
 
 **Depends on:** Phases 2, 4, 5
 
-- [ ] **6.1** Update `.claude/settings.json` to document agent teams configuration:
+- [x] **6.1** Update `.claude/settings.json` to document agent teams configuration:
   - Add commented `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` entry in env section
   - Document the opt-in nature and fallback behavior
 
-- [ ] **6.2** Refactor `plugins/principled-implementation/skills/orchestrate/SKILL.md`:
+- [x] **6.2** Refactor `plugins/principled-implementation/skills/orchestrate/SKILL.md`:
   - Add detection logic: check if `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` is set
   - When enabled: populate agent teams task list from manifest, spawn teammates per independent task, use task dependency tracking for ordering
   - When disabled: use existing sequential `/spawn` loop (no behavior change)
   - Add documentation section explaining both execution modes
   - Reference ADR-016 for the architectural decision
 
-- [ ] **6.3** Add `TeammateIdle` handling to orchestrate skill:
+- [x] **6.3** Add `TeammateIdle` handling to orchestrate skill:
   - When a teammate finishes its task and others are still running, reassign to review or cleanup work
   - Document the reassignment strategy in the skill's reference docs
 
-- [ ] **6.4** Update `plugins/principled-implementation/skills/impl-strategy/reference/orchestration-guide.md`:
+- [x] **6.4** Update `plugins/principled-implementation/skills/impl-strategy/reference/orchestration-guide.md`:
   - Add section on agent teams execution mode
   - Document the dual state model (task list + manifest)
   - Explain the fallback guarantee
   - Add decision framework: when to use agent teams vs. sequential
 
-- [ ] **6.5** Update root `CLAUDE.md`:
+- [x] **6.5** Update root `CLAUDE.md`:
   - Add agent teams to the Architecture table
   - Update the Agents section to list all 6 agents (1 existing + 5 new)
   - Update the Hooks section to reflect new hook events and counts
@@ -336,35 +337,35 @@ Tasks are organized by phase, with each phase mapping to one or more bounded con
 
 **Depends on:** Phase 6
 
-- [ ] **7.1** Update `plugins/principled-docs/README.md`:
+- [x] **7.1** Update `plugins/principled-docs/README.md`:
   - Document 3 new guard hooks with trigger conditions and behavior
   - Document async drift advisory hook
   - Document ADR supersession advisory hook
   - Document 2 new agents (module-auditor, decision-auditor)
 
-- [ ] **7.2** Update `plugins/principled-implementation/README.md`:
+- [x] **7.2** Update `plugins/principled-implementation/README.md`:
   - Document 4 new lifecycle hooks
   - Document agent teams integration and fallback behavior
   - Document impl-worker frontmatter upgrades
   - Update task lifecycle state machine if needed
 
-- [ ] **7.3** Update `plugins/principled-github/README.md`:
+- [x] **7.3** Update `plugins/principled-github/README.md`:
   - Document issue-ingester agent
 
-- [ ] **7.4** Update `plugins/principled-quality/README.md`:
+- [x] **7.4** Update `plugins/principled-quality/README.md`:
   - Document pr-reviewer agent
 
-- [ ] **7.5** Update `plugins/principled-architecture/README.md`:
+- [x] **7.5** Update `plugins/principled-architecture/README.md`:
   - Document boundary-checker agent
 
-- [ ] **7.6** Run full CI validation:
+- [x] **7.6** Run full CI validation:
   - ShellCheck and shfmt on all new `.sh` files
   - markdownlint-cli2 and Prettier on all new `.md` files
   - Template drift checks for all 6 plugins
   - Structure validation via `/validate --root`
   - Marketplace manifest validation
 
-- [ ] **7.7** Update `/test-hooks` skill to include test cases for all new hooks:
+- [x] **7.7** Update `/test-hooks` skill to include test cases for all new hooks:
   - Plan-proposal link guard: valid/invalid proposal references
   - Required frontmatter guard: complete/incomplete frontmatter per doc type
   - Document numbering guard: unique/duplicate numbers
@@ -393,20 +394,50 @@ Tasks are organized by phase, with each phase mapping to one or more bounded con
 
 ## Acceptance Criteria
 
-- [ ] `check-plan-proposal-link.sh` blocks writing a plan without an accepted proposal (exit 2) and allows valid plans (exit 0)
-- [ ] `check-required-frontmatter.sh` blocks documents with missing or invalid frontmatter and allows valid documents
-- [ ] `check-doc-numbering.sh` blocks duplicate document numbers and allows unique numbers and re-writes
-- [ ] `setup-impl-worktree.sh` initializes `.impl/` in new worktrees when a manifest exists
-- [ ] `cleanup-impl-worktree.sh` archives state when worktrees are removed
-- [ ] `validate-worker-completion.sh` rejects impl-worker completion when tasks are orphaned in `in_progress`
-- [ ] `gate-task-completion.sh` rejects task completion when quality checks have not passed
-- [ ] `async-drift-check.sh` runs drift checks in the background after template/script writes
-- [ ] `check-adr-supersession.sh` warns about invalid or circular supersession chains
-- [ ] All 5 new agents are loadable via `/agents` command and have valid frontmatter
-- [ ] `impl-worker.md` includes `maxTurns`, `memory`, and scoped hooks
-- [ ] `/orchestrate` uses agent teams when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set
-- [ ] `/orchestrate` falls back to sequential execution when agent teams are disabled
-- [ ] All new hook scripts pass ShellCheck and shfmt
-- [ ] All new markdown files pass markdownlint-cli2 and Prettier
-- [ ] Template drift checks pass for all 6 plugins
-- [ ] `/test-hooks` includes test cases for all new hooks
+- [x] `check-plan-proposal-link.sh` blocks writing a plan without an accepted proposal (exit 2) and allows valid plans (exit 0)
+- [x] `check-required-frontmatter.sh` blocks documents with missing or invalid frontmatter and allows valid documents
+- [x] `check-doc-numbering.sh` blocks duplicate document numbers and allows unique numbers and re-writes
+- [x] `setup-impl-worktree.sh` initializes `.impl/` in new worktrees when a manifest exists
+- [x] `cleanup-impl-worktree.sh` archives state when worktrees are removed
+- [x] `validate-worker-completion.sh` rejects impl-worker completion when tasks are orphaned in `in_progress`
+- [x] `gate-task-completion.sh` rejects task completion when quality checks have not passed
+- [x] `async-drift-check.sh` runs drift checks in the background after template/script writes
+- [x] `check-adr-supersession.sh` warns about invalid or circular supersession chains
+- [x] All 5 new agents are loadable via `/agents` command and have valid frontmatter
+- [x] `impl-worker.md` includes `maxTurns`, `memory`, and scoped hooks
+- [x] `/orchestrate` uses agent teams when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set
+- [x] `/orchestrate` falls back to sequential execution when agent teams are disabled
+- [x] All new hook scripts pass ShellCheck and shfmt
+- [x] All new markdown files pass markdownlint-cli2 and Prettier
+- ~~Template drift checks pass for all 6 plugins~~ — **superseded by [ADR-018](../decisions/018-shared-plugin-lib-over-copies.md).** Only two drift checks remain, and both pass: principled-docs scaffolding templates and the cross-plugin `check-gh-cli.sh`.
+- [x] `/test-hooks` includes test cases for all new hooks — delivered as `tests/hooks.bats` (57 tests over all 11 hooks, including the no-jq fallback); the skill runs that suite
+
+---
+
+## Completion Record
+
+Verified 2026-07-29 against the repository. The boxes above were ticked from that
+verification, not from memory of the work.
+
+**Evidence.** All three docs guard hooks (`check-plan-proposal-link.sh`,
+`check-required-frontmatter.sh`, `check-doc-numbering.sh`), both advisory hooks
+(`async-drift-check.sh`, `check-adr-supersession.sh`) and all four implementation
+lifecycle hooks (`setup-impl-worktree.sh`, `cleanup-impl-worktree.sh`,
+`validate-worker-completion.sh`, `gate-task-completion.sh`) exist and are declared in
+their `hooks.json`. All five new agents exist. `impl-worker.md` carries `maxTurns: 100`,
+`memory: project` and a scoped `Stop` hook. `.claude/agent-memory/` is gitignored.
+`tests/hooks.bats` passes with 57 tests over every hook, including the no-jq fallback
+path; the full suite is 185 tests green, and CI is green on `main`.
+
+**One task was genuinely outstanding** and was completed on 2026-07-29 rather than ticked
+falsely: 5.3, the root `CLAUDE.md` section on agent memory governance.
+
+**One acceptance criterion was superseded.** "Template drift checks pass for all 6
+plugins" assumed the copy-with-drift convention of ADR-009;
+[ADR-018](../decisions/018-shared-plugin-lib-over-copies.md) replaced it. Two drift
+checks remain and both pass.
+
+**Delivery differed on testing.** Task 7.7 planned per-hook cases inside the `/test-hooks`
+skill. Hook testing was instead consolidated into `tests/hooks.bats`
+([ADR-019](../decisions/019-bats-for-shell-testing.md)), which the skill now runs — the
+same coverage, executable in CI.

--- a/docs/plans/009-principled-tasks.md
+++ b/docs/plans/009-principled-tasks.md
@@ -4,7 +4,7 @@ number: "009"
 status: complete
 author: Alex
 created: 2026-02-27
-updated: 2026-07-28
+updated: 2026-07-29
 originating_proposal: "009"
 ---
 
@@ -90,20 +90,20 @@ This implementation decomposes into **5 bounded contexts**, each representing a 
 
 **Goal:** Create the complete directory tree, plugin manifest, and canonical task-db.sh script.
 
-- [ ] **1.1** Create `.claude-plugin/plugin.json` with name, version, description, author, homepage, keywords
-- [ ] **1.2** Create the full directory skeleton: all skill directories, hook directory, scripts directory
-- [ ] **1.3** Implement `skills/task-open/scripts/task-db.sh` (canonical):
-  - [ ] `--init` — Create `.impl/tasks.db` with beads and bead_edges tables
-  - [ ] `--open` — Insert a new bead with generated ID, title, status, timestamps
-  - [ ] `--close` — Update bead status to done/abandoned, set closed_at
-  - [ ] `--add-edge` — Insert a typed edge between two beads
-  - [ ] `--get` — Retrieve a single bead by ID
-  - [ ] `--list` — List beads with optional filters (plan, status, agent)
-  - [ ] `--graph` — Output bead graph (optional DOT format)
-  - [ ] `--audit` — Run audit queries (orphans, stale, cycles)
-  - [ ] `--commit` — Git add and commit tasks.db
-- [ ] **1.4** Copy `task-db.sh` to: task-close, task-graph, task-audit, task-query
-- [ ] **1.5** Implement `scripts/check-template-drift.sh` for all 4 copy pairs
+- [x] **1.1** Create `.claude-plugin/plugin.json` with name, version, description, author, homepage, keywords
+- [x] **1.2** Create the full directory skeleton: all skill directories, hook directory, scripts directory
+- [x] **1.3** Implement `task-db.sh` (shipped at `lib/task-db.sh`, not under a skill — see Completion Record):
+  - [x] `--init` — Create `.impl/tasks.db` with beads and bead_edges tables
+  - [x] `--open` — Insert a new bead with generated ID, title, status, timestamps
+  - [x] `--close` — Update bead status to done/abandoned, set closed_at
+  - [x] `--add-edge` — Insert a typed edge between two beads
+  - [x] `--get` — Retrieve a single bead by ID
+  - [x] `--list` — List beads with optional filters (plan, status, agent)
+  - [x] `--graph` — Output bead graph (optional DOT format)
+  - [x] `--audit` — Run audit queries (orphans, stale, cycles)
+  - [x] `--commit` — Git add and commit tasks.db
+- ~~**1.4** Copy `task-db.sh` to: task-close, task-graph, task-audit, task-query~~ — **superseded by [ADR-018](../decisions/018-shared-plugin-lib-over-copies.md).** One copy in `lib/`; nothing to propagate.
+- ~~**1.5** Implement `scripts/check-template-drift.sh` for all 4 copy pairs~~ — **superseded by [ADR-018](../decisions/018-shared-plugin-lib-over-copies.md).** With no copies there is no drift to detect; `scripts/check-skill-references.sh` verifies the `${CLAUDE_PLUGIN_ROOT}/lib/` reference instead.
 
 ### Phase 2: Knowledge System & Hook (BC-3, Hook)
 
@@ -111,23 +111,23 @@ This implementation decomposes into **5 bounded contexts**, each representing a 
 
 **Depends on:** Phase 1 (directory skeleton exists)
 
-- [ ] **2.1** Write `skills/task-strategy/reference/task-model.md`:
-  - [ ] Bead lifecycle: open → in_progress → done/blocked/abandoned
-  - [ ] Edge semantics: blocks, spawned_by, part_of, related_to
-  - [ ] Discovery chains: how discovered_from links tasks
-  - [ ] Integration with principled-implementation manifests
-- [ ] **2.2** Write `skills/task-strategy/reference/schema.md`:
-  - [ ] Complete CREATE TABLE statements with commentary
-  - [ ] Field descriptions, constraints, indexing notes
-  - [ ] Example queries for common operations
-- [ ] **2.3** Write `skills/task-strategy/SKILL.md`:
-  - [ ] Background knowledge skill (not user-invocable)
-  - [ ] When to consult, reference documentation pointers
-- [ ] **2.4** Implement `hooks/scripts/check-db-integrity.sh`:
-  - [ ] Read JSON from stdin (tool_input.file_path)
-  - [ ] Warn if path matches `.impl/tasks.db`
-  - [ ] Advisory only — always exit 0
-- [ ] **2.5** Write `hooks/hooks.json` with PreToolUse advisory hook
+- [x] **2.1** Write `skills/task-strategy/reference/task-model.md`:
+  - [x] Bead lifecycle: open → in_progress → done/blocked/abandoned
+  - [x] Edge semantics: blocks, spawned_by, part_of, related_to
+  - [x] Discovery chains: how discovered_from links tasks
+  - [x] Integration with principled-implementation manifests
+- [x] **2.2** Write `skills/task-strategy/reference/schema.md`:
+  - [x] Complete CREATE TABLE statements with commentary
+  - [x] Field descriptions, constraints, indexing notes
+  - [x] Example queries for common operations
+- [x] **2.3** Write `skills/task-strategy/SKILL.md`:
+  - [x] Background knowledge skill (not user-invocable)
+  - [x] When to consult, reference documentation pointers
+- [x] **2.4** Implement `hooks/scripts/check-db-integrity.sh`:
+  - [x] Read JSON from stdin (tool_input.file_path)
+  - [x] Warn if path matches `.impl/tasks.db`
+  - [x] Advisory only — always exit 0
+- [x] **2.5** Write `hooks/hooks.json` with PreToolUse advisory hook
 
 ### Phase 3: Write Skills (BC-4)
 
@@ -135,17 +135,17 @@ This implementation decomposes into **5 bounded contexts**, each representing a 
 
 **Depends on:** Phase 1 (task-db.sh canonical exists)
 
-- [ ] **3.1** Write `skills/task-open/SKILL.md`:
-  - [ ] Parse arguments: title, --plan, --blocks, --discovered-from
-  - [ ] Initialize DB if needed
-  - [ ] Generate bead ID, insert bead, add edges
-  - [ ] Git commit after write
-  - [ ] Report created bead
-- [ ] **3.2** Write `skills/task-close/SKILL.md`:
-  - [ ] Parse arguments: id, --notes
-  - [ ] Update bead status to done, set closed_at and notes
-  - [ ] Git commit after write
-  - [ ] Report closed bead
+- [x] **3.1** Write `skills/task-open/SKILL.md`:
+  - [x] Parse arguments: title, --plan, --blocks, --discovered-from
+  - [x] Initialize DB if needed
+  - [x] Generate bead ID, insert bead, add edges
+  - [x] Git commit after write
+  - [x] Report created bead
+- [x] **3.2** Write `skills/task-close/SKILL.md`:
+  - [x] Parse arguments: id, --notes
+  - [x] Update bead status to done, set closed_at and notes
+  - [x] Git commit after write
+  - [x] Report closed bead
 
 ### Phase 4: Read Skills (BC-5)
 
@@ -153,18 +153,18 @@ This implementation decomposes into **5 bounded contexts**, each representing a 
 
 **Depends on:** Phase 1 (task-db.sh canonical exists)
 
-- [ ] **4.1** Write `skills/task-graph/SKILL.md`:
-  - [ ] Parse arguments: --plan, --open, --dot
-  - [ ] Query beads and edges, filter as requested
-  - [ ] Render as table or DOT graph
-- [ ] **4.2** Write `skills/task-audit/SKILL.md`:
-  - [ ] Parse arguments: --plan, --agent
-  - [ ] Run audit queries: orphan beads, stale in_progress, blocked chains, agent workload
-  - [ ] Report findings with recommendations
-- [ ] **4.3** Write `skills/task-query/SKILL.md`:
-  - [ ] Parse natural-language question
-  - [ ] Translate to SQL using schema knowledge
-  - [ ] Execute and format results
+- [x] **4.1** Write `skills/task-graph/SKILL.md`:
+  - [x] Parse arguments: --plan, --open, --dot
+  - [x] Query beads and edges, filter as requested
+  - [x] Render as table or DOT graph
+- [x] **4.2** Write `skills/task-audit/SKILL.md`:
+  - [x] Parse arguments: --plan, --agent
+  - [x] Run audit queries: orphan beads, stale in_progress, blocked chains, agent workload
+  - [x] Report findings with recommendations
+- [x] **4.3** Write `skills/task-query/SKILL.md`:
+  - [x] Parse natural-language question
+  - [x] Translate to SQL using schema knowledge
+  - [x] Execute and format results
 
 ### Phase 5: Documentation & Integration (Plugin Docs)
 
@@ -172,8 +172,8 @@ This implementation decomposes into **5 bounded contexts**, each representing a 
 
 **Depends on:** Phases 1–4
 
-- [ ] **5.1** Write plugin `README.md` with badges, quick start, skills table, hook description, architecture
-- [ ] **5.2** Register plugin in `.claude-plugin/marketplace.json`
+- [x] **5.1** Write plugin `README.md` with badges, quick start, skills table, hook description, architecture
+- [x] **5.2** Register plugin in `.claude-plugin/marketplace.json`
 
 ---
 
@@ -197,18 +197,18 @@ This implementation decomposes into **5 bounded contexts**, each representing a 
 
 ## Acceptance Criteria
 
-- [ ] `/task-open "Fix login bug" --plan 003` creates a bead in `.impl/tasks.db` and commits
-- [ ] `/task-open "Refactor auth" --blocks bead-001 --discovered-from bead-002` creates bead with edges
-- [ ] `/task-close bead-001 --notes "Resolved via PR #42"` updates status and commits
-- [ ] `/task-graph` displays all beads and edges as a formatted table
-- [ ] `/task-graph --plan 003 --open --dot` outputs DOT format filtered to plan 003 open beads
-- [ ] `/task-audit` reports orphan beads, stale in_progress, and agent workload
-- [ ] `/task-query "what tasks are blocked?"` translates to SQL and returns results
-- [ ] `check-db-integrity.sh` warns on direct `.impl/tasks.db` edits (exit 0)
-- [ ] `check-template-drift.sh` passes when all task-db.sh copies match canonical
-- [ ] `check-template-drift.sh` fails when a copy diverges
-- [ ] Plugin registered in marketplace.json with correct source path
-- [ ] All skills are self-contained with their own SKILL.md and scripts
+- [x] `/task-open "Fix login bug" --plan 003` creates a bead in `.impl/tasks.db` and commits
+- [x] `/task-open "Refactor auth" --blocks bead-001 --discovered-from bead-002` creates bead with edges
+- [x] `/task-close bead-001 --notes "Resolved via PR #42"` updates status and commits
+- [x] `/task-graph` displays all beads and edges as a formatted table
+- [x] `/task-graph --plan 003 --open --dot` outputs DOT format filtered to plan 003 open beads
+- [x] `/task-audit` reports orphan beads, stale in_progress, and agent workload
+- [x] `/task-query "what tasks are blocked?"` translates to SQL and returns results
+- [x] `check-db-integrity.sh` warns on direct `.impl/tasks.db` edits (exit 0) — and on `.principled/tasks.jsonl`, the record it turned out to matter more to protect
+- ~~`check-template-drift.sh` passes when all task-db.sh copies match canonical~~ — **superseded by [ADR-018](../decisions/018-shared-plugin-lib-over-copies.md).**
+- ~~`check-template-drift.sh` fails when a copy diverges~~ — **superseded by [ADR-018](../decisions/018-shared-plugin-lib-over-copies.md).**
+- [x] Plugin registered in marketplace.json with correct source path
+- ~~All skills are self-contained with their own SKILL.md and scripts~~ — **superseded by [ADR-018](../decisions/018-shared-plugin-lib-over-copies.md).** Every skill has its own SKILL.md; shared code is referenced from `lib/`, not copied into each skill.
 
 ---
 
@@ -225,3 +225,30 @@ This implementation decomposes into **5 bounded contexts**, each representing a 
 | §3 Skills (read)       | Phase 4    | 4.1–4.3   |
 | §6 Git Commitment      | Phase 3, 4 | 3.1, 3.2  |
 | Plugin Docs            | Phase 5    | 5.1, 5.2  |
+
+---
+
+## Completion Record
+
+Verified 2026-07-29 against the repository. The boxes above were ticked from that
+verification, not from memory of the work.
+
+**Evidence.** All 7 skills present under `plugins/principled-tasks/skills/` (the plan
+scoped 6; `task-update` was added during implementation). `lib/task-db.sh` implements
+every operation the plan listed — `--init`, `--open`, `--close`, `--add-edge`, `--get`,
+`--list`, `--graph`, `--audit`, `--commit` — plus `--update` and `--sync`. Reference docs,
+`hooks/hooks.json`, `hooks/scripts/check-db-integrity.sh`, the plugin README, and the
+`marketplace.json` entry all exist. `tests/task-db.bats` covers the library end to end and
+passes.
+
+**Divergences from the plan as written.** Three, all deliberate:
+
+1. **Storage.** The plan says "bead in `.impl/tasks.db`". [ADR-017](../decisions/017-event-log-task-graph.md)
+   made `.principled/tasks.jsonl` the record and SQLite a derived cache, so writes append
+   to the log and commit it; the cache is rebuilt and gitignored. The plan's "bead"
+   vocabulary became "task" throughout.
+2. **Shared code.** Tasks 1.4, 1.5 and two acceptance criteria described a canonical
+   script copied into four skills with a drift checker. [ADR-018](../decisions/018-shared-plugin-lib-over-copies.md)
+   replaced that with a single `lib/task-db.sh`. Those items are struck through above
+   rather than ticked: the work was not done, and should not have been.
+3. **Skill count.** 7 shipped against 6 planned.


### PR DESCRIPTION
## What

Two things, found together: the pipeline audit's five standing warnings, and the fact that the local commit gate had been failing for a while without CI noticing.

### Plan records

`pipeline-audit.sh` warned that five `complete` plans had unticked checkboxes. The audit deliberately makes this a warning, and its own comment warns against ticking boxes wholesale to silence CI. Verifying them against the repository is what made that warning earn its keep — **eleven of the tasks describe work that was deliberately never done.**

Plans 000, 001, 007, 008 and 009 are ticked from verified evidence: files present, scripts executed against this repo, tests green. Each plan now carries a **Completion Record** stating what was checked, when, and where delivery diverged from the plan as written.

The eleven superseded items are **struck through rather than ticked**. They describe the copy-with-drift scheme that [ADR-018](../blob/main/docs/decisions/018-shared-plugin-lib-over-copies.md) replaced with `lib/` — ticking them would record that a regression had shipped. [ADR-017](../blob/main/docs/decisions/017-event-log-task-graph.md) (event log rather than `.impl/tasks.db`) and [ADR-019](../blob/main/docs/decisions/019-bats-for-shell-testing.md) (bats rather than per-hook cases in `/test-hooks`) account for the remainder.

One task was **genuinely outstanding**, not superseded: plan-008's task 5.3, the agent memory governance section in root `CLAUDE.md`. It is now written rather than falsely ticked, and draws the line between gitignored `memory: project` scratch space and the committed, reviewed `.agents/memory/` that did not exist when that plan was authored.

### The pre-commit gate

Running the gate surfaced that the gate was broken. `pre-commit run --all-files` is step one of the commit checklist in `.claude/CLAUDE.md`, and it failed three ways — none visible to CI:

- **Three hooks invoked deleted scripts.** `impl-`, `github-` and `quality-template-drift` still called per-plugin `check-template-drift.sh` files that ADR-018 removed, exiting **127** each. CI had already dropped those steps, so nothing caught the dangling references.
- **`mirrors-prettier` disagrees with CI's prettier.** It pins its own older version, which rewrites Markdown tables containing `|` inside code spans — files the repo's pinned prettier reports as clean. It mangled plan-000's tables on contact during this work. Prettier now runs as a `local` hook against `npx prettier`, exactly as CI does.
- **shfmt and shellcheck were unscoped**, linting `.bats` files that CI never checks and failing on style CI does not enforce. Both are scoped to `*.sh` now.

Four CI steps had **no local counterpart at all** — cross-plugin drift, skill reference integrity, pipeline audit, root structure validation — so a clean local run proved less than it looked like. All four are added. The bats suite stays out on purpose: it runs in CI and via `just test`.

## Verification

- `pre-commit run --all-files` — 9/9 pass (previously 3 hard failures plus file rewrites)
- `just ci` — all checks pass, 185/185 bats tests
- `scripts/pipeline-audit.sh` — **0 issues, 0 warnings** (was 0 issues, 5 warnings)

## Not in scope

Version stays at **0.5.0**. Ten stale remote branches were pruned separately; they had already been deleted server-side on merge, leaving only local tracking refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)