### PR TITLE
chore: move GitHub Actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     name: Shell Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install shfmt
         run: |
@@ -30,9 +30,9 @@ jobs:
     name: Markdown Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm
@@ -50,9 +50,9 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm
@@ -69,9 +69,9 @@ jobs:
     name: Bash 3.2 Compatibility
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm
@@ -89,7 +89,7 @@ jobs:
     name: Validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Check skill and hook script references resolve
         run: bash scripts/check-skill-references.sh

--- a/plugins/principled-agent/skills/agent-dispatch/templates/agent-dispatch.yml
+++ b/plugins/principled-agent/skills/agent-dispatch/templates/agent-dispatch.yml
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # worktree isolation and changelog generation need history
 
@@ -89,9 +89,9 @@ jobs:
           echo "No halt in effect."
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Install the Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code

--- a/plugins/principled-github/skills/gh-scaffold/templates/label-sync-workflow.yml
+++ b/plugins/principled-github/skills/gh-scaffold/templates/label-sync-workflow.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Sync labels
         env:

--- a/plugins/principled-github/skills/gh-scaffold/templates/pr-check-workflow.yml
+++ b/plugins/principled-github/skills/gh-scaffold/templates/pr-check-workflow.yml
@@ -9,7 +9,7 @@ jobs:
     name: Validate PR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Check PR description
         env:


### PR DESCRIPTION
## What

Every CI run was emitting:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/checkout@v4`, `actions/setup-node@v4`

Nothing was failing — but being force-migrated is a grace period, not a fix. Both actions move to **v7** (latest: checkout v7.0.1, setup-node v7.0.0).

## Why v7 is safe here

The intermediate majors carry breaking changes, none of which apply to this repo:

| Version | Breaking change | Applies here? |
|---|---|---|
| checkout v5/v6 | node24 runtime; credentials persisted to a separate file | No behavioural impact |
| checkout v7 | Blocks fork-PR checkout under `pull_request_target` / `workflow_run` | **No** — neither trigger appears anywhere in the repo |
| setup-node v5 | Automatic caching when `package.json` has a `packageManager` field | **No** — no such field; every call site sets `cache: npm` explicitly |
| setup-node v6 | Automatic caching narrowed to npm | **No** — npm is what we use |

Requires runner ≥ v2.327.1, which GitHub-hosted `ubuntu-latest` far exceeds.

## Scope beyond our own CI

Of the twelve pins, **three are in workflow templates the plugins ship**:

- `principled-agent/skills/agent-dispatch/templates/agent-dispatch.yml`
- `principled-github/skills/gh-scaffold/templates/label-sync-workflow.yml`
- `principled-github/skills/gh-scaffold/templates/pr-check-workflow.yml`

Those generate workflows in *other people's* repositories. Left alone, `/gh-scaffold` would keep emitting freshly deprecated YAML — which matters more than the warning on our own runs.

The dispatch template also pinned `node-version: "20"` outright — the exact runtime the deprecation is about. It now matches CI at `22`.

## Verification

- All four workflow files parse as YAML
- `pre-commit run --all-files` — 9/9 pass
- `just ci` — all checks pass, 185/185 bats tests
- No remaining `@v4` pins: `grep -rn 'actions/checkout@\|actions/setup-node@'` returns v7 for all 12

🤖 Generated with [Claude Code](https://claude.com/claude-code)